### PR TITLE
fix: re-add the optional wavelength edges

### DIFF
--- a/docs/examples/amor.ipynb
+++ b/docs/examples/amor.ipynb
@@ -36,6 +36,7 @@
     "    Filename[Sample]: \"sample.nxs\",\n",
     "    SampleRotation[Reference]: sc.scalar(0.8389, unit='deg'),\n",
     "    Filename[Reference]: \"reference.nxs\",\n",
+    "    WavelengthEdges: sc.array(dims=['wavelength'], values=[2.4, 16.0], unit='angstrom'),\n",
     "}"
    ]
   },
@@ -121,7 +122,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "essreflectometry",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -139,5 +140,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/essreflectometry/amor/__init__.py
+++ b/src/essreflectometry/amor/__init__.py
@@ -7,7 +7,14 @@ import scipp as sc
 
 from .. import providers as reflectometry_providers
 from .. import supermirror
-from ..types import BeamSize, DetectorSpatialResolution, Gravity, Run, SampleSize
+from ..types import (
+    BeamSize,
+    DetectorSpatialResolution,
+    Gravity,
+    Run,
+    SampleSize,
+    WavelengthEdges,
+)
 from . import beamline, conversions, load, resolution
 from .beamline import instrument_view_components
 from .instrument_view import instrument_view

--- a/src/essreflectometry/conversions.py
+++ b/src/essreflectometry/conversions.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from typing import Optional
+
 import scipp as sc
 from scipp.constants import h, m_n, pi
 from scippneutron._utils import elem_dtype, elem_unit
@@ -16,6 +18,7 @@ from .types import (
     SpecularReflectionCoordTransformGraph,
     ThetaData,
     WavelengthData,
+    WavelengthEdges,
 )
 
 
@@ -118,6 +121,7 @@ def specular_reflection() -> SpecularReflectionCoordTransformGraph:
 def tof_to_wavelength(
     data_array: RawData[Run],
     graph: SpecularReflectionCoordTransformGraph,
+    wavelength_edges: Optional[WavelengthEdges],
 ) -> WavelengthData[Run]:
     """
     Use :code:`transform_coords` to convert from ToF to wavelength, cutoff high and
@@ -129,6 +133,8 @@ def tof_to_wavelength(
         Data array to convert.
     graph:
         Graph for :code:`transform_coords`.
+    wavelength_edges:
+        Bounds for wavelength values, exclude data outside of bounds.
 
     Returns
     -------
@@ -136,6 +142,8 @@ def tof_to_wavelength(
         New data array with wavelength dimension.
     """
     data_array_wav = data_array.transform_coords(["wavelength"], graph=graph)
+    if wavelength_edges is not None:
+        data_array_wav = data_array_wav.bin({wavelength_edges.dim: wavelength_edges})
     # TODO
     # try:
     #    from orsopy import fileio

--- a/src/essreflectometry/types.py
+++ b/src/essreflectometry/types.py
@@ -66,6 +66,9 @@ QResolution = NewType('QResolution', sc.Variable)
 QBins = NewType('QBins', sc.Variable)
 '''Bins for the momentum transfer histogram.'''
 
+WavelengthEdges = NewType('WavelengthEdges', sc.Variable)
+'''Include only events within the specified edges.'''
+
 
 class Filename(sciline.Scope[Run, str], str):
     """Filename of the event data nexus file."""


### PR DESCRIPTION
The edges were removed by mistake when the workflow was ported from ess to essreflectometry.

This PR re-adds them to the workflow.