### PR TITLE
Re-run comparison to PSI + some minor fixes

### DIFF
--- a/docs/user-guide/amor/compare-to-eos.ipynb
+++ b/docs/user-guide/amor/compare-to-eos.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "for i in `seq 608 613`\n",
     "do\n",
-    "    python amor/neos.py $args -f $i -o $i $args \n",
+    "    python amor/neos.py $args -f $i -o $i\n",
     "done\n",
     "```"
    ]
@@ -223,7 +223,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/src/ess/amor/__init__.py
+++ b/src/ess/amor/__init__.py
@@ -14,6 +14,7 @@ from ..reflectometry.types import (
     NeXusDetectorName,
     RunType,
     SamplePosition,
+    BeamDivergenceLimits,
 )
 from . import conversions, data, load, orso, resolution, utils
 from .instrument_view import instrument_view
@@ -64,6 +65,7 @@ def default_parameters() -> dict:
         NeXusDetectorName[RunType]: "detector",
         ChopperPhase[RunType]: sc.scalar(-5.0, unit="deg"),
         ChopperFrequency[RunType]: sc.scalar(8.333, unit="Hz"),
+        BeamDivergenceLimits: (sc.scalar(-0.7, unit='deg'), sc.scalar(0.7, unit='deg')),
     }
 
 

--- a/src/ess/amor/data.py
+++ b/src/ess/amor/data.py
@@ -3,7 +3,7 @@
 
 from ..reflectometry.types import Filename, ReferenceRun, SampleRun
 
-_version = "1"
+_version = "2"
 
 
 def _make_pooch():
@@ -42,14 +42,14 @@ def _make_pooch():
             "amor2023n000614.hdf": "md5:18e8a755d6fd671758fe726de058e707",
             # Reflectivity curves obtained by applying Jochens Amor
             # software @ https://github.com/jochenstahn/amor.git
-            # (repo commit hash e05fc9e1e124965919647f1856dbb9eb04221f1e).
+            # (repo commit hash 05e35ca4e05436d7c69ff6e19f32bc1915cbb5d0).
             # to the above files.
-            "608.Rqz.ort": "md5:60d8467796800f19c3aa1b6af5ad7b3d",
-            "609.Rqz.ort": "md5:99af745e025423af64bc5a124a011826",
-            "610.Rqz.ort": "md5:fa703dc9c5eed49d35e7a3d76a5746b9",
-            "611.Rqz.ort": "md5:d6ea74d0525308a6a42938c106b62919",
-            "612.Rqz.ort": "md5:f0b0eb269614645b4c6bbe24e29a6e10",
-            "613.Rqz.ort": "md5:fff003552908c6a4a94b6213cfa08ac3",
+            "608.Rqz.ort": "md5:e7e7d63a1ac1e727e9b2f12dc78a77ce",
+            "609.Rqz.ort": "md5:3cb3fd11a743594f52a10f71b122b71a",
+            "610.Rqz.ort": "md5:66d43993e76801655a1d629cb976abde",
+            "611.Rqz.ort": "md5:0c51e8ac5c00041434417673be186151",
+            "612.Rqz.ort": "md5:d785d27151e7f1edc05e86d35bef6a63",
+            "613.Rqz.ort": "md5:e999c85f7a47665c4ddd1538b19d402d",
         },
     )
 

--- a/src/ess/reflectometry/conversions.py
+++ b/src/ess/reflectometry/conversions.py
@@ -149,6 +149,9 @@ def add_masks(
     wb: WavelengthBins,
     zlim: ZIndexLimits,
 ) -> MaskedData[RunType]:
+    da.masks["beam_divergence_too_large"] = sc.abs(
+        da.coords["angle_from_center_of_beam"]
+    ) > sc.scalar(0.7, unit='deg')
     da.masks["y_index_range"] = (da.coords["y_index"] < ylim[0]) | (
         da.coords["y_index"] > ylim[1]
     )

--- a/src/ess/reflectometry/conversions.py
+++ b/src/ess/reflectometry/conversions.py
@@ -7,6 +7,7 @@ from scippneutron.conversion.beamline import scattering_angle_in_yz_plane
 from scippneutron.conversion.graph import beamline, tof
 
 from .types import (
+    BeamDivergenceLimits,
     DataWithScatteringCoordinates,
     Gravity,
     IncidentBeam,
@@ -148,10 +149,11 @@ def add_masks(
     ylim: YIndexLimits,
     wb: WavelengthBins,
     zlim: ZIndexLimits,
+    bdlim: BeamDivergenceLimits,
 ) -> MaskedData[RunType]:
-    da.masks["beam_divergence_too_large"] = sc.abs(
-        da.coords["angle_from_center_of_beam"]
-    ) > sc.scalar(0.7, unit='deg')
+    da.masks["beam_divergence_too_large"] = (
+        da.coords["angle_from_center_of_beam"] < bdlim[0]
+    ) | (da.coords["angle_from_center_of_beam"] > bdlim[1])
     da.masks["y_index_range"] = (da.coords["y_index"] < ylim[0]) | (
         da.coords["y_index"] > ylim[1]
     )

--- a/src/ess/reflectometry/types.py
+++ b/src/ess/reflectometry/types.py
@@ -124,5 +124,9 @@ ZIndexLimits = NewType("ZIndexLimits", tuple[sc.Variable, sc.Variable])
 """Limit of the (logical) 'z' detector pixel index"""
 
 
+BeamDivergenceLimits = NewType("BeamDivergenceLimits", tuple[sc.Variable, sc.Variable])
+"""Limit of the beam divergence"""
+
+
 ReferenceFilePath = NewType("ReferenceFilePath", str)
 """Path to the cached normalization matrix"""


### PR DESCRIPTION
I was looking at resolving the discrepancy in the result compared to PSI and as part of that I re-ran the Jochens Amor code to re-create the reference files that I was comparing against.

Surprisingly the results are now much closer.
There are two possible reasons:

* I made a slight change in the command line arguments used to create the files, I don't think it should make a difference, but it might.
* The Amor reduction workflow has changed on their end and the changes made the results more similar.

In any case, I uploaded the new reference files to our file-server.