### PR TITLE
ci: needs pooch to run tests during release

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -30,6 +30,7 @@ test:
     - ess.amor
   requires:
     - pytest
+    - pooch
   source_files:
     - pyproject.toml
     - tests/


### PR DESCRIPTION
The release fails because the tests that are run before conda package release doesn't have the right dependencies.