### PR TITLE
WIP: proton charge correction

### DIFF
--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -7,10 +7,13 @@ from ess.reduce import nexus
 from ..reflectometry.load import load_nx
 from ..reflectometry.types import (
     DetectorRotation,
+    EventData,
     Filename,
     LoadedNeXusDetector,
     NeXusDetectorName,
+    ProtonCurrent,
     RawDetectorData,
+    RawEventData,
     ReducibleDetectorData,
     RunType,
     SampleRotation,
@@ -31,8 +34,23 @@ def load_detector(
     return nexus.load_detector(file_path=file_path, detector_name=detector_name)
 
 
+def load_events_binned_in_time(
+    detector: LoadedNeXusDetector[RunType],
+) -> RawEventData[RunType]:
+    da = nexus.extract_detector_data(detector)
+    # Recent versions of scippnexus no longer add variances for events by default, so
+    # we add them here if they are missing.
+    if da.bins.constituents["data"].data.variances is None:
+        da.bins.constituents["data"].data.variances = da.bins.constituents[
+            "data"
+        ].data.values
+    return RawEventData[RunType](da)
+
+
 def load_events(
-    detector: LoadedNeXusDetector[RunType], detector_rotation: DetectorRotation[RunType]
+    event_data: EventData[RunType],
+    detector: LoadedNeXusDetector[RunType],
+    detector_rotation: DetectorRotation[RunType],
 ) -> RawDetectorData[RunType]:
     detector_numbers = sc.arange(
         "event_id",
@@ -42,9 +60,8 @@ def load_events(
         dtype="int32",
     )
     data = (
-        nexus.extract_detector_data(detector)
-        .bins.constituents["data"]
-        .group(detector_numbers)
+        event_data.bins.concat()
+        .value.group(detector_numbers)
         .fold(
             "event_id",
             sizes={
@@ -54,13 +71,6 @@ def load_events(
             },
         )
     )
-    # Recent versions of scippnexus no longer add variances for events by default, so
-    # we add them here if they are missing.
-    if data.bins.constituents["data"].data.variances is None:
-        data.bins.constituents["data"].data.variances = data.bins.constituents[
-            "data"
-        ].data.values
-
     pixel_inds = sc.array(dims=data.dims, values=data.coords["event_id"].values - 1)
     position, angle_from_center_of_beam = pixel_coordinate_in_lab_frame(
         pixelID=pixel_inds, nu=detector_rotation
@@ -156,9 +166,35 @@ def load_amor_detector_rotation(fp: Filename[RunType]) -> DetectorRotation[RunTy
     return sc.scalar(nu['value'].data['dim_1', 0]['time', 0].value, unit='deg')
 
 
+def load_proton_current(
+    detector: LoadedNeXusDetector[RunType],
+) -> ProtonCurrent[RunType]:
+    pc = detector['proton_current']['value']
+    if pc.size == 0:
+        # If the proton current log is empty, fill it with a default value
+        # This is to continue support for old amor files that don't contain
+        # information about the proton current.
+        pc = ProtonCurrent[RunType](
+            sc.DataArray(
+                data=sc.array(
+                    dims=['time', 'dim_1'],
+                    values=[[1.0]],
+                ),
+                coords={
+                    'time': sc.array(
+                        dims=['time'], values=[0], dtype='datetime64', unit='ns'
+                    )
+                },
+            )
+        )
+    pc.unit = pc.unit or 'dimensionless'
+    return ProtonCurrent[RunType](pc['dim_1', 0])
+
+
 providers = (
     load_detector,
     load_events,
+    load_events_binned_in_time,
     compute_tof,
     load_amor_ch_frequency,
     load_amor_ch_phase,
@@ -167,4 +203,5 @@ providers = (
     load_amor_sample_rotation,
     load_amor_detector_rotation,
     amor_chopper,
+    load_proton_current,
 )

--- a/src/ess/amor/resolution.py
+++ b/src/ess/amor/resolution.py
@@ -4,8 +4,8 @@ import scipp as sc
 
 from ..reflectometry.tools import fwhm_to_std
 from ..reflectometry.types import (
+    CorrectedData,
     DetectorSpatialResolution,
-    FootprintCorrectedData,
     QBins,
     QResolution,
     SampleRun,
@@ -21,7 +21,7 @@ from .types import (
 
 
 def wavelength_resolution(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     chopper_1_position: Chopper1Position[SampleRun],
     chopper_2_position: Chopper2Position[SampleRun],
 ) -> WavelengthResolution:
@@ -53,7 +53,7 @@ def wavelength_resolution(
 
 
 def sample_size_resolution(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     sample_size: SampleSize[SampleRun],
 ) -> SampleSizeResolution:
     """
@@ -84,7 +84,7 @@ def sample_size_resolution(
 
 
 def angular_resolution(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     detector_spatial_resolution: DetectorSpatialResolution[SampleRun],
 ) -> AngularResolution:
     """
@@ -126,7 +126,7 @@ def angular_resolution(
 
 
 def sigma_Q(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     angular_resolution: AngularResolution,
     wavelength_resolution: WavelengthResolution,
     sample_size_resolution: SampleSizeResolution,

--- a/src/ess/reflectometry/normalize.py
+++ b/src/ess/reflectometry/normalize.py
@@ -6,7 +6,7 @@ import scipp as sc
 from scipy.optimize import OptimizeWarning
 
 from .types import (
-    FootprintCorrectedData,
+    CorrectedData,
     IdealReferenceIntensity,
     NormalizationFactor,
     NormalizedIofQ,
@@ -18,7 +18,7 @@ from .types import (
 
 
 def normalization_factor(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     corr: IdealReferenceIntensity,
     wbins: WavelengthBins,
 ) -> NormalizationFactor:
@@ -77,21 +77,23 @@ def normalization_factor(
             ),
             p0={"a": sc.scalar(-1e-3, unit="1/angstrom")},
         )
-    return sc.DataArray(
-        data=corr.data,
-        coords={
-            "Q": q_of_z_wavelength(
-                wm,
-                sc.values(p["a"]),
-                sc.values(p["b"]),
-            ).data,
-        },
-        masks=corr.masks,
+    return NormalizationFactor(
+        sc.DataArray(
+            data=corr.data,
+            coords={
+                "Q": q_of_z_wavelength(
+                    wm,
+                    sc.values(p["a"]),
+                    sc.values(p["b"]),
+                ).data,
+            },
+            masks=corr.masks,
+        )
     )
 
 
 def reflectivity_over_q(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     n: NormalizationFactor,
     qbins: QBins,
 ) -> NormalizedIofQ:
@@ -116,7 +118,7 @@ def reflectivity_over_q(
 
 
 def reflectivity_per_event(
-    da: FootprintCorrectedData[SampleRun],
+    da: CorrectedData[SampleRun],
     n: IdealReferenceIntensity,
     wbins: WavelengthBins,
 ) -> ReflectivityData:

--- a/src/ess/reflectometry/orso.py
+++ b/src/ess/reflectometry/orso.py
@@ -19,8 +19,8 @@ from orsopy.fileio import data_source, orso, reduction
 from .load import load_nx
 from .supermirror import SupermirrorReflectivityCorrection
 from .types import (
+    CorrectedData,
     Filename,
-    FootprintCorrectedData,
     ReducibleDetectorData,
     ReferenceRun,
     SampleRun,
@@ -175,7 +175,7 @@ def build_orso_data_source(
 
 _CORRECTIONS_BY_GRAPH_KEY = {
     ReducibleDetectorData[SampleRun]: "chopper ToF correction",
-    FootprintCorrectedData[SampleRun]: "footprint correction",
+    CorrectedData[SampleRun]: "footprint correction",
     SupermirrorReflectivityCorrection: "supermirror calibration",
 }
 

--- a/src/ess/reflectometry/types.py
+++ b/src/ess/reflectometry/types.py
@@ -33,6 +33,15 @@ class RawDetectorData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     binned by `detector_number` (pixel of the detector frame)."""
 
 
+class EventData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Event data from nexus file, binned by pulse.
+    Holds time dependent masks and coords."""
+
+
+class RawEventData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Raw event data from nexus file, binned by pulse."""
+
+
 class LoadedNeXusDetector(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
     """NXdetector loaded from file"""
 
@@ -50,9 +59,16 @@ class MaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Event data that has been masked in wavelength and logical detector coordinates"""
 
 
-class FootprintCorrectedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
-    """Event data with weights corrected for the footprint of the beam
-    on the sample for the incidence angle of the event."""
+class FootprintCorrection(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Weights of the footprint of the beam on the sample."""
+
+
+class ProtonCurrentCorrection(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Weights of the proton current correction"""
+
+
+class CorrectedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """MaskedData corrected by footprint and proton current"""
 
 
 ReferenceIntensity = NewType("ReferenceIntensity", sc.DataArray)
@@ -109,6 +125,10 @@ class DetectorSpatialResolution(sciline.Scope[RunType, sc.Variable], sc.Variable
 class SampleSize(sciline.Scope[RunType, sc.Variable], sc.Variable):
     # TODO is this radius or total length?
     """Size of the sample. If None it is assumed to be the same as the reference."""
+
+
+class ProtonCurrent(sciline.Scope[RunType, sc.Variable], sc.Variable):
+    """Proton current log of the measurement"""
 
 
 Gravity = NewType("Gravity", sc.Variable)


### PR DESCRIPTION
Fixes #78 

Some questions remain, mainly about correctness and if this structure is really practical.

It would be nice to be able to compute the corrections (statically) and apply them all in one provider.
But that's not possible because they have different shapes.
The proton charge correction is a function of the pulse time and the other corrections are functions of detector pixels and/or wavelength.

Another option is to just store `event_time_zero` on the events and lookup the proton charge for each event instead of for each pulse. It's less efficient, but probably not so inefficient that it becomes relevant.