### PR TITLE
fix: include resolution in stitched curve if present

### DIFF
--- a/src/ess/reflectometry/tools.py
+++ b/src/ess/reflectometry/tools.py
@@ -261,7 +261,8 @@ def combine_curves(
     inv_v = 1.0 / v
     r_avg = np.nansum(r * inv_v, axis=0) / np.nansum(inv_v, axis=0)
     v_avg = 1 / np.nansum(inv_v, axis=0)
-    return sc.DataArray(
+
+    out = sc.DataArray(
         data=sc.array(
             dims='Q',
             values=r_avg,
@@ -270,3 +271,25 @@ def combine_curves(
         ),
         coords={'Q': qgrid},
     )
+    if any('Q_resolution' in c.coords for c in curves):
+        # This might need to be revisited. The question about how to combine curves
+        # with different Q-resolution is not completely resolved.
+        # However, in practice the difference in Q-resolution between different curves
+        # is small so it's not likely to make a big difference.
+        q_res = (
+            sc.DataArray(
+                data=c.coords.get(
+                    'Q_resolution', sc.scalar(float('nan')) * sc.values(c.data.copy())
+                ),
+                coords={'Q': c.coords['Q']},
+            )
+            for c in curves
+        )
+        qs = _interpolate_on_qgrid(q_res, qgrid).values
+        qs_avg = np.nansum(qs * inv_v, axis=0) / np.nansum(
+            ~np.isnan(qs) * inv_v, axis=0
+        )
+        out.coords['Q_resolution'] = sc.array(
+            dims='Q', values=qs_avg, unit=next(iter(curves)).coords['Q_resolution'].unit
+        )
+    return out

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import pytest
 import scipp as sc
 from scipp.testing import assert_allclose
 
@@ -126,3 +127,26 @@ def test_combined_curves():
             ],
         ),
     )
+
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered in divide")
+def test_combined_curves_resolution():
+    qgrid = sc.linspace('Q', 0, 1, 26)
+    data = sc.concat(
+        (
+            sc.ones(dims=['Q'], shape=[10], with_variances=True),
+            0.5 * sc.ones(dims=['Q'], shape=[15], with_variances=True),
+        ),
+        dim='Q',
+    )
+    data.variances[:] = 0.1
+    curves = (
+        curve(data, 0, 0.3),
+        curve(0.5 * data, 0.2, 0.7),
+        curve(0.25 * data, 0.6, 1.0),
+    )
+    curves[0].coords['Q_resolution'] = sc.midpoints(curves[0].coords['Q']) / 5
+    combined = combine_curves(curves, qgrid)
+    assert 'Q_resolution' in combined.coords
+    assert combined.coords['Q_resolution'][0] == curves[0].coords['Q_resolution'][1]
+    assert sc.isnan(combined.coords['Q_resolution'][-1])


### PR DESCRIPTION
Adds a `Q_resolution` coordinate to the combined reflectivity curve if the provided curves have a `Q_resolution` coordinate.