### PR TITLE
feat: add orso providers for estia

### DIFF
--- a/src/ess/amor/orso.py
+++ b/src/ess/amor/orso.py
@@ -1,112 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
-"""ORSO utilities for Amor."""
-
-import numpy as np
-import scipp as sc
-from orsopy.fileio import base as orso_base
-from orsopy.fileio import data_source as orso_data_source
-from orsopy.fileio.orso import Column, Orso, OrsoDataset
-
-from ..reflectometry.orso import (
-    OrsoDataSource,
-    OrsoInstrument,
-    OrsoIofQDataset,
-    OrsoReduction,
-)
-from ..reflectometry.types import ReflectivityOverQ
+from ess.reflectometry.orso import OrsoCorrectionList
 
 
-def build_orso_instrument(events: ReflectivityOverQ) -> OrsoInstrument:
-    """Build ORSO instrument metadata from intermediate reduction results for Amor.
-
-    This assumes specular reflection and sets the incident angle equal to the computed
-    scattering angle.
-    """
-    return OrsoInstrument(
-        orso_data_source.InstrumentSettings(
-            wavelength=orso_base.ValueRange(*_limits_of_coord(events, "wavelength")),
-            incident_angle=orso_base.ValueRange(*_limits_of_coord(events, "theta")),
-            polarization=None,  # TODO how can we determine this from the inputs?
-        )
+def orso_amor_corrections() -> OrsoCorrectionList:
+    return OrsoCorrectionList(
+        [
+            "chopper ToF correction",
+            "footprint correction",
+            "supermirror calibration",
+        ]
     )
 
 
-def build_orso_iofq_dataset(
-    iofq: ReflectivityOverQ,
-    data_source: OrsoDataSource,
-    reduction: OrsoReduction,
-) -> OrsoIofQDataset:
-    """Build an ORSO dataset for reduced I-of-Q data and associated metadata."""
-    header = Orso(
-        data_source=data_source,
-        reduction=reduction,
-        columns=[
-            Column("Qz", "1/angstrom", "wavevector transfer"),
-            Column("R", None, "reflectivity"),
-            Column("sR", None, "standard deviation of reflectivity"),
-            Column(
-                "sQz",
-                "1/angstrom",
-                "standard deviation of wavevector transfer resolution",
-            ),
-        ],
-    )
-    iofq = iofq.hist()
-
-    qz = iofq.coords["Q"].to(unit="1/angstrom", copy=False)
-    if iofq.coords.is_edges("Q"):
-        qz = sc.midpoints(qz)
-    r = sc.values(iofq.data)
-    sr = sc.stddevs(iofq.data)
-    sqz = iofq.coords["Q_resolution"].to(unit="1/angstrom", copy=False)
-
-    data = np.column_stack(tuple(map(_extract_values_array, (qz, r, sr, sqz))))
-    data = data[np.isfinite(data).all(axis=-1)]
-    ds = OrsoIofQDataset(OrsoDataset(header, data))
-    ds.info.reduction.corrections = [
-        "chopper ToF correction",
-        "footprint correction",
-        "supermirror calibration",
-    ]
-    return ds
-
-
-def _extract_values_array(var: sc.Variable) -> np.ndarray:
-    if var.variances is not None:
-        raise sc.VariancesError(
-            "ORT columns must not have variances. "
-            "Store the uncertainties as standard deviations in a separate column."
-        )
-    if var.ndim != 1:
-        raise sc.DimensionError(f"ORT columns must be one-dimensional, got {var.sizes}")
-    return var.values
-
-
-def _limits_of_coord(data: sc.DataArray, name: str) -> tuple[float, float, str] | None:
-    if (coord := _get_coord(data, name)) is None:
-        return None
-    min_ = coord.min().value
-    max_ = coord.max().value
-    # Explicit conversions to float because orsopy does not like np.float* types.
-    return float(min_), float(max_), _ascii_unit(coord.unit)
-
-
-def _get_coord(data: sc.DataArray, name: str) -> sc.Variable | None:
-    if name in data.coords:
-        return sc.DataArray(data=data.coords[name], masks=data.masks)
-    if (data.bins is not None) and (name in data.bins.coords):
-        # Note that .bins.concat() applies the top-level masks
-        events = data.bins.concat().value
-        return sc.DataArray(data=events.coords[name], masks=events.masks)
-    return None
-
-
-def _ascii_unit(unit: sc.Unit) -> str:
-    unit = str(unit)
-    if unit == "Å":
-        return "angstrom"
-    return unit
-
-
-providers = (build_orso_instrument, build_orso_iofq_dataset)
+providers = (orso_amor_corrections,)

--- a/src/ess/estia/__init__.py
+++ b/src/ess/estia/__init__.py
@@ -15,7 +15,7 @@ from ..reflectometry.types import (
     RunType,
     SamplePosition,
 )
-from . import conversions, load, maskings, normalization, resolution, workflow
+from . import conversions, load, maskings, normalization, orso, resolution, workflow
 from .types import (
     AngularResolution,
     SampleSizeResolution,
@@ -35,6 +35,7 @@ providers = (
     *maskings.providers,
     *workflow.providers,
     *normalization.providers,
+    *orso.providers,
 )
 """
 List of providers for setting up a Sciline pipeline.

--- a/src/ess/estia/orso.py
+++ b/src/ess/estia/orso.py
@@ -1,112 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""ORSO utilities for Estia."""
-
-import numpy as np
-import scipp as sc
-from orsopy.fileio import base as orso_base
-from orsopy.fileio import data_source as orso_data_source
-from orsopy.fileio.orso import Column, Orso, OrsoDataset
-
-from ..reflectometry.orso import (
-    OrsoDataSource,
-    OrsoInstrument,
-    OrsoIofQDataset,
-    OrsoReduction,
-)
-from ..reflectometry.types import ReducibleData, ReflectivityOverQ, SampleRun
+from ess.reflectometry.orso import OrsoCorrectionList
 
 
-def build_orso_instrument(events: ReducibleData[SampleRun]) -> OrsoInstrument:
-    """Build ORSO instrument metadata from intermediate reduction results for Estia.
-
-    This assumes specular reflection and sets the incident angle equal to the computed
-    scattering angle.
-    """
-    return OrsoInstrument(
-        orso_data_source.InstrumentSettings(
-            wavelength=orso_base.ValueRange(*_limits_of_coord(events, "wavelength")),
-            incident_angle=orso_base.ValueRange(*_limits_of_coord(events, "theta")),
-            polarization=None,  # TODO how can we determine this from the inputs?
-        )
+def orso_estia_corrections() -> OrsoCorrectionList:
+    return OrsoCorrectionList(
+        [
+            "chopper ToF correction",
+            "footprint correction",
+            "supermirror calibration",
+        ]
     )
 
 
-def build_orso_iofq_dataset(
-    iofq: ReflectivityOverQ,
-    data_source: OrsoDataSource,
-    reduction: OrsoReduction,
-) -> OrsoIofQDataset:
-    """Build an ORSO dataset for reduced I-of-Q data and associated metadata."""
-    header = Orso(
-        data_source=data_source,
-        reduction=reduction,
-        columns=[
-            Column("Qz", "1/angstrom", "wavevector transfer"),
-            Column("R", None, "reflectivity"),
-            Column("sR", None, "standard deviation of reflectivity"),
-            Column(
-                "sQz",
-                "1/angstrom",
-                "standard deviation of wavevector transfer resolution",
-            ),
-        ],
-    )
-    iofq = iofq.hist()
-
-    qz = iofq.coords["Q"].to(unit="1/angstrom", copy=False)
-    if iofq.coords.is_edges("Q"):
-        qz = sc.midpoints(qz)
-    r = sc.values(iofq.data)
-    sr = sc.stddevs(iofq.data)
-    sqz = iofq.coords["Q_resolution"].to(unit="1/angstrom", copy=False)
-
-    data = np.column_stack(tuple(map(_extract_values_array, (qz, r, sr, sqz))))
-    data = data[np.isfinite(data).all(axis=-1)]
-    ds = OrsoIofQDataset(OrsoDataset(header, data))
-    ds.info.reduction.corrections = [
-        "chopper ToF correction",
-        "footprint correction",
-        "supermirror calibration",
-    ]
-    return ds
-
-
-def _extract_values_array(var: sc.Variable) -> np.ndarray:
-    if var.variances is not None:
-        raise sc.VariancesError(
-            "ORT columns must not have variances. "
-            "Store the uncertainties as standard deviations in a separate column."
-        )
-    if var.ndim != 1:
-        raise sc.DimensionError(f"ORT columns must be one-dimensional, got {var.sizes}")
-    return var.values
-
-
-def _limits_of_coord(data: sc.DataArray, name: str) -> tuple[float, float, str] | None:
-    if (coord := _get_coord(data, name)) is None:
-        return None
-    min_ = coord.min().value
-    max_ = coord.max().value
-    # Explicit conversions to float because orsopy does not like np.float* types.
-    return float(min_), float(max_), _ascii_unit(coord.unit)
-
-
-def _get_coord(data: sc.DataArray, name: str) -> sc.Variable | None:
-    if name in data.coords:
-        return sc.DataArray(data=data.coords[name], masks=data.masks)
-    if (data.bins is not None) and (name in data.bins.coords):
-        # Note that .bins.concat() applies the top-level masks
-        events = data.bins.concat().value
-        return sc.DataArray(data=events.coords[name], masks=events.masks)
-    return None
-
-
-def _ascii_unit(unit: sc.Unit) -> str:
-    unit = str(unit)
-    if unit == "Å":
-        return "angstrom"
-    return unit
-
-
-providers = (build_orso_instrument, build_orso_iofq_dataset)
+providers = (orso_estia_corrections,)

--- a/src/ess/estia/orso.py
+++ b/src/ess/estia/orso.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""ORSO utilities for Estia."""
+
+import numpy as np
+import scipp as sc
+from orsopy.fileio import base as orso_base
+from orsopy.fileio import data_source as orso_data_source
+from orsopy.fileio.orso import Column, Orso, OrsoDataset
+
+from ..reflectometry.orso import (
+    OrsoDataSource,
+    OrsoInstrument,
+    OrsoIofQDataset,
+    OrsoReduction,
+)
+from ..reflectometry.types import ReducibleData, ReflectivityOverQ, SampleRun
+
+
+def build_orso_instrument(events: ReducibleData[SampleRun]) -> OrsoInstrument:
+    """Build ORSO instrument metadata from intermediate reduction results for Estia.
+
+    This assumes specular reflection and sets the incident angle equal to the computed
+    scattering angle.
+    """
+    return OrsoInstrument(
+        orso_data_source.InstrumentSettings(
+            wavelength=orso_base.ValueRange(*_limits_of_coord(events, "wavelength")),
+            incident_angle=orso_base.ValueRange(*_limits_of_coord(events, "theta")),
+            polarization=None,  # TODO how can we determine this from the inputs?
+        )
+    )
+
+
+def build_orso_iofq_dataset(
+    iofq: ReflectivityOverQ,
+    data_source: OrsoDataSource,
+    reduction: OrsoReduction,
+) -> OrsoIofQDataset:
+    """Build an ORSO dataset for reduced I-of-Q data and associated metadata."""
+    header = Orso(
+        data_source=data_source,
+        reduction=reduction,
+        columns=[
+            Column("Qz", "1/angstrom", "wavevector transfer"),
+            Column("R", None, "reflectivity"),
+            Column("sR", None, "standard deviation of reflectivity"),
+            Column(
+                "sQz",
+                "1/angstrom",
+                "standard deviation of wavevector transfer resolution",
+            ),
+        ],
+    )
+    iofq = iofq.hist()
+
+    qz = iofq.coords["Q"].to(unit="1/angstrom", copy=False)
+    if iofq.coords.is_edges("Q"):
+        qz = sc.midpoints(qz)
+    r = sc.values(iofq.data)
+    sr = sc.stddevs(iofq.data)
+    sqz = iofq.coords["Q_resolution"].to(unit="1/angstrom", copy=False)
+
+    data = np.column_stack(tuple(map(_extract_values_array, (qz, r, sr, sqz))))
+    data = data[np.isfinite(data).all(axis=-1)]
+    ds = OrsoIofQDataset(OrsoDataset(header, data))
+    ds.info.reduction.corrections = [
+        "chopper ToF correction",
+        "footprint correction",
+        "supermirror calibration",
+    ]
+    return ds
+
+
+def _extract_values_array(var: sc.Variable) -> np.ndarray:
+    if var.variances is not None:
+        raise sc.VariancesError(
+            "ORT columns must not have variances. "
+            "Store the uncertainties as standard deviations in a separate column."
+        )
+    if var.ndim != 1:
+        raise sc.DimensionError(f"ORT columns must be one-dimensional, got {var.sizes}")
+    return var.values
+
+
+def _limits_of_coord(data: sc.DataArray, name: str) -> tuple[float, float, str] | None:
+    if (coord := _get_coord(data, name)) is None:
+        return None
+    min_ = coord.min().value
+    max_ = coord.max().value
+    # Explicit conversions to float because orsopy does not like np.float* types.
+    return float(min_), float(max_), _ascii_unit(coord.unit)
+
+
+def _get_coord(data: sc.DataArray, name: str) -> sc.Variable | None:
+    if name in data.coords:
+        return sc.DataArray(data=data.coords[name], masks=data.masks)
+    if (data.bins is not None) and (name in data.bins.coords):
+        # Note that .bins.concat() applies the top-level masks
+        events = data.bins.concat().value
+        return sc.DataArray(data=events.coords[name], masks=events.masks)
+    return None
+
+
+def _ascii_unit(unit: sc.Unit) -> str:
+    unit = str(unit)
+    if unit == "Å":
+        return "angstrom"
+    return unit
+
+
+providers = (build_orso_instrument, build_orso_iofq_dataset)

--- a/src/ess/reflectometry/orso.py
+++ b/src/ess/reflectometry/orso.py
@@ -11,14 +11,19 @@ import platform
 from datetime import datetime, timezone
 from typing import NewType
 
+import numpy as np
+import scipp as sc
 from dateutil.parser import parse as parse_datetime
 from orsopy.fileio import base as orso_base
 from orsopy.fileio import data_source, orso, reduction
+from orsopy.fileio.orso import Column, Orso, OrsoDataset
 
 from .load import load_nx
 from .types import (
     Filename,
+    ReducibleData,
     ReferenceRun,
+    ReflectivityOverQ,
     SampleRun,
 )
 
@@ -51,6 +56,8 @@ OrsoSample = NewType("OrsoSample", data_source.Sample)
 
 OrsoSampleFilenames = NewType("OrsoSampleFilenames", list[orso_base.File])
 """Collection of filenames used to create the ORSO file"""
+
+OrsoCorrectionList = NewType("OrsoCorrectionList", list[str])
 
 
 def parse_orso_experiment(filename: Filename[SampleRun]) -> OrsoExperiment:
@@ -171,6 +178,95 @@ def build_orso_data_source(
     )
 
 
+def build_orso_instrument(events: ReducibleData[SampleRun]) -> OrsoInstrument:
+    """Build ORSO instrument metadata from intermediate reduction results.
+
+    This assumes specular reflection and sets the incident angle equal to the computed
+    scattering angle.
+    """
+    return OrsoInstrument(
+        data_source.InstrumentSettings(
+            wavelength=orso_base.ValueRange(*_limits_of_coord(events, "wavelength")),
+            incident_angle=orso_base.ValueRange(*_limits_of_coord(events, "theta")),
+            polarization=None,  # TODO how can we determine this from the inputs?
+        )
+    )
+
+
+def build_orso_iofq_dataset(
+    iofq: ReflectivityOverQ,
+    data_source: OrsoDataSource,
+    reduction: OrsoReduction,
+    corrections: OrsoCorrectionList,
+) -> OrsoIofQDataset:
+    """Build an ORSO dataset for reduced I-of-Q data and associated metadata."""
+    header = Orso(
+        data_source=data_source,
+        reduction=reduction,
+        columns=[
+            Column("Qz", "1/angstrom", "wavevector transfer"),
+            Column("R", None, "reflectivity"),
+            Column("sR", None, "standard deviation of reflectivity"),
+            Column(
+                "sQz",
+                "1/angstrom",
+                "standard deviation of wavevector transfer resolution",
+            ),
+        ],
+    )
+    iofq = iofq.hist()
+
+    qz = iofq.coords["Q"].to(unit="1/angstrom", copy=False)
+    if iofq.coords.is_edges("Q"):
+        qz = sc.midpoints(qz)
+    r = sc.values(iofq.data)
+    sr = sc.stddevs(iofq.data)
+    sqz = iofq.coords["Q_resolution"].to(unit="1/angstrom", copy=False)
+
+    data = np.column_stack(tuple(map(_extract_values_array, (qz, r, sr, sqz))))
+    data = data[np.isfinite(data).all(axis=-1)]
+    ds = OrsoIofQDataset(OrsoDataset(header, data))
+    ds.info.reduction.corrections = list(corrections)
+    return ds
+
+
+def _extract_values_array(var: sc.Variable) -> np.ndarray:
+    if var.variances is not None:
+        raise sc.VariancesError(
+            "ORT columns must not have variances. "
+            "Store the uncertainties as standard deviations in a separate column."
+        )
+    if var.ndim != 1:
+        raise sc.DimensionError(f"ORT columns must be one-dimensional, got {var.sizes}")
+    return var.values
+
+
+def _limits_of_coord(data: sc.DataArray, name: str) -> tuple[float, float, str] | None:
+    if (coord := _get_coord(data, name)) is None:
+        return None
+    min_ = coord.min().value
+    max_ = coord.max().value
+    # Explicit conversions to float because orsopy does not like np.float* types.
+    return float(min_), float(max_), _ascii_unit(coord.unit)
+
+
+def _get_coord(data: sc.DataArray, name: str) -> sc.Variable | None:
+    if name in data.coords:
+        return sc.DataArray(data=data.coords[name], masks=data.masks)
+    if (data.bins is not None) and (name in data.bins.coords):
+        # Note that .bins.concat() applies the top-level masks
+        events = data.bins.concat().value
+        return sc.DataArray(data=events.coords[name], masks=events.masks)
+    return None
+
+
+def _ascii_unit(unit: sc.Unit) -> str:
+    unit = str(unit)
+    if unit == "Å":
+        return "angstrom"
+    return unit
+
+
 providers = (
     build_orso_data_source,
     build_orso_measurement,
@@ -179,4 +275,6 @@ providers = (
     parse_orso_owner,
     parse_orso_sample,
     orso_data_files,
+    build_orso_instrument,
+    build_orso_iofq_dataset,
 )


### PR DESCRIPTION
Only very minor changes were made to the Amor orso provider.

Maybe it would make sense to move parts of the `ess/amor/orso` module to `ess/reflectometry/orso` instead of duplicating it for estia.