### PR TITLE
Split user guide and cards on index pages

### DIFF
--- a/docs/_static/thumbnails/estia_advanced_mcstas_reduction_dark.svg
+++ b/docs/_static/thumbnails/estia_advanced_mcstas_reduction_dark.svg
@@ -1,0 +1,775 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="216pt" height="180pt" viewBox="0 0 216 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-06-10T13:10:47.066434</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 216 180 
+L 216 0 
+L 0 0 
+L 0 180 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+L 199.731508 6.799459 
+L 52.30649 6.799459 
+L 52.30649 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <g clip-path="url(#p9d7e79933a)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM0AAADBCAYAAABsfjQSAAAYm0lEQVR4nO2deYwlR33Hv1XV3e+Y2WPWu14feHzbgC0MRhBwUBIh/ooUEUscQiAFSICgKEHBGMfiCI4NeDGHCESKISIJEjgJRgn5IwREohDC2lEICYrB2Mbr9dre9bHHzM7Mu7qrKn/U8arfMd7nY6/5fqTRe9NdVV3dr371+9Wvfl0FEEIIIYQQQgghZMMgwpf7951lF7MWDAwkJPZVXXxr5SW4/orvivWLIGRjIU90BQg51ahpEX3gEhu+L5suDmuN/bqNX7lwD7UNIZ6apunbEtoaaGugIKAEsEN18e0HX2S/9PPX2OnFELJxoHlGyIzUhOYp3UcFDQMLDQsJQMHi3OwoXtV6CP/+0EX2xp9cS41DNjTUNITMSE1ovrb8MqyYAfq2RMdoGH9cQyAXBjtUF+9YuAv/8/AL7IVf/zg1DtmQjHnF/mXPZfaqYhU9a7BiBbQVMD5ZLgy2SSAXEqU12PXUa/DZl32DnjWyoaB5RsiMTNQS9+472zaFxZqRKCGRw0AJi7awKIRAWyhISHyvuxV7Bmfi63tfgf/+9U9S45ANwURNc+fy1VgxKpplJSS0FVgxw+QlNOZkH9vUKt554W6850dv4ziHbAhonhEyI1NNqr974Gp7QX4QChZSWChYNIXGFinQFAqlNfiv/hY8pTdjzTTw2GABhwbz2N/djPsPnol7r72J5ho5LaGmIWRGpgrNmy79sXhcb4aGgLHjSiMXLqvyszm50DijWMVC0cULdzyBy+68ieMbclqyrqb5s0dei6f0JgBAaaUTIH+utO7Nm4FVUDBoyBISFi1VYqHo4przHsIbd7/bvvXud1J4yGkFzTNCZmRdofnOr/2p2DvYjp7NAADaCmhrUVrjM7v5Gw2J0mQwcNEDlZXYVqzh8vkn8LqFn+Gr9/+SveBrdEeT04On1TS/96LvC53M18SMQkAJA20FFAyUcIKUCY2WKgEAbTnAnBzghcUB/PZLduPNu99FwSGnPDTPCJmRYxKaJdPGABLGCmgAJSz61kBbOTTPrAIA9E2G0rjvPZOjKQdQsNiZL+OC9iG8/gfvtS/5xw9T45BTFmoaQmbkmITmrtVLYaxEz2YovY44pAXOy5axVa2htAqlVThSttGQFYwV6JsM2/MV7B3sgIbAwWoTOqbA4twRXL3zUbz+B++1V37rI9Q45JSDmoaQGcmOJdEnr/p78bo9l1kAaIouGkJik9SAX0OgKUo0RBW9Zn2TYV71Y/6m0FjI1tAzuc9j0FAVmjsqnPtvf2Dh3dvPxw0S8lxzzJrmsWoBj1ULKAEYa1FaRFMtOAGMrYfcGCthQiSBfwPUQEAKl3FT3sP25iq2N1edg+D3P0tzjZz00DwjZEZmNonuefgcu0NZLBunFB4oz8C+8gwcLDfhydLFqXV1js1ZDxc3nwQAXNN+ELs7F+NAuRUA0NEFSqswMBl0opkqo6IW+sor/5rmGjkpOaYxTcqyaeAM1YsqKjW9QsSzsdKfGyqyXGhIWH/e5ZH+XR0AaKkBcqHxwtZ+d50fvsd+85dvp+CQkw6aZ4TMyMya5u7uxdih7sEgaBM7lDs9IoO5cB4291qBjGsOaDgHgYFA5tMYK7Al7+KMbBUAcGZjFa/85xvs449sAwDse9cN1DrkpICahpAZmVlornvx98Qh04ju4xQFAwWDyo5qHIPSKjeG8eOaTOo4ppE+fk1biaYo0RQl5rI+drZXsf2cZWw/ZxmLX7mV7mhyUvCMNM3P+2djxRRYMQUMZGzww0Jtbb4m98IUaMgK8IKTHnOvGriycqHRzgbY3Oxhc7OHhR0ruPhvbqbgkBMOzTNCZmRmRwAAvOPyu8UdD7w89vphUK9rL6kNtU2JuiOgMhID4y4dHAGVX4jQjMhxKKPINLZs6uLF//BRe971XQDAdx64jc4Bctx5RkIDAPf3zgYALBYH47HKv0djIFBaFYWo9KZbGM/AC0vlw2/ghcyZZVXtWJjHaWYVSiMxVwyw/EVX3qVHb7IPvPGPKTjkuELzjJAZecZC8/2nLsX3n7oUy3ouBmxmUsfBvYJBLjRyoaFgoWBqHjcpbM17BiCuMxCorEQmDDJhYKxAM6vQzgdYaHax0OziyrMP4Nr/+F06B8hxhZqGkBl5xmOaf33t5wQAXP2/b7DbsjUgGdNoK+LbnIHSZjW3dEgbPnOla+Urr2EC2grk/ns7GwAANmV9XDG/H9nud1sA2PeFy/Cfd3yAYxzyvPKsNc1Pl8/Gim7GxTQmEZaAUsIt9VRaBRmWfPImXTTR4BZbD+UpaaCkQS79WmtiaI01VIWd+TIun38Cl88/gewdT2Dxrz5Jc408r9A8I2RGnrXQfPtXvyAOl3M1UwwjGkF5V3OY7XdzOBLSD/DT6IGBVRhY5R0Ew/PGimiuNVWJpnJrR+eiiuWe2V7BOWcfwUV33GIvuuMWahzyvPCcaJqfHTkLS2UbXZ2jq3MMTIaBydAxBTqmwFHbQMcUcZxTGYW+ydA3WXwlujL1UJzhS2rD490qR2UkOlWBTlX4dBmaskRTlsi8Cddq99Fq92mqkecFmmeEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQggh5LTkuKxG+arvfPAaAD9c7rSwte22yTi82saWuS4OLc9hx9bVmLadl3jpwqP4v6Vz8MiRragqhcGKW3lGtTSkNCi7OVSzwgu2LwEA9t23Exe+6AAe+uk5aJyzBmP84oT3zKO3Q8MWFlAWatktM7X5siM4sn8LRClgMwvZlzBzfoXPSkDMVbjgqwJPvryBe299vwCAxds/ZeVcCXu0gCgF9r6PK3luVLgaDSEzclx6y7fc9TvXAPhh2DYQgF/zTMRFAVuqBADsKFZxZetR7F65BI92tuJIv421gdc00qCZVWhlbrHAxbkjAICr5/biwf5O3Le6E6tlA33tlqheHRSotIKx8J/uds+Y60AIi8cObnUPQVoUhaubFBZFptHIKrTyEhdtcvvvbM56+NGhRRxea2NtrQnddVpLrmYojkjc/7H3U/NsEKhpCJmR4yI0S4MWlgYt9M1wk4JcajRUhYas0JAaSlj/N9zXplBuYfSwCLoUNq6i2c7KWFYh3E7RhaxQyCouY9vMKhSZ0yDW70yQK42tjS4yaSCkhVQGWabjPjlSWAh/HQmLedWPf62sRLsxQLM1gGpXUO0KZr5Cb2eF879wG1fz3CA84602ZuHeR88CAFy1+Gi8Yi41tBXQEMiRbqkhoYSp7dk5Vmnptl0P53Oh3YZRVqKyKq753DcZtJGQAlBeGABACoNcakhpYS2glIkbG0ppYK2A8MIatkDMhYb2+4IqOayvyCystbANg8W/vNXKoxmdBKc5NM8ImZHjomn2vvVDuwGIc797vT2zvQL43j4QthKE38NGon4uELpvCYvMm3FI9r8JhC0KRaJdXFnus1AaK2UT1gJCAMZIyLj/jdMk1muxthzUyoQ39bLMXbvUwpUjLVRu0NjaxRXf+ogFgJ++/mZqnNOQ4yI0gUf2b0P7fNcIM+l2OpPCmVp50ihLm6G0amwbjkBqmsFvyb5aNWL6IICh4Qtv6hkvPwOtUGoFYwSUqg9FtBEoMgPhxzdt5eqb7kyd1sgaASEAlRvkRYVNrR7OnV929fzmx+xg7zweuo7m2ukEzTNCZuS4Cs2+t98oVgYNrAwa6FSF7/2lr4gz0YIjIMVaEbVGurlTQArjvF3JTtEAUBkZ80lhYzmF96IFRwCA6L0L17B+Dinsj9O3WUyX6iahLCDdMSktNhd9FFKjkNpd76w+Lt71GXrWTiOoaQiZkeMuNAceX8CBxxfQrzIMks1tDURtsJ2L4ea1ouYutrV08NsTuugCUxt7ZLKukZS0UNJOHSsFwlxNZWSsVy40hNcySlgYI2KMm5AWSpk4n9RSpftrDKCUQblzgAs+/2lqm9OE4+oIAICHf+tGAQBnfvuPbCOrIIV1cyZJY9d+oF8Z9xnmRyDN8DhE3OczeM/cPI2MQlX5fGHeRZuhqVZqBeHlxlpEISqUqZlncddqXwVtJLQdOhCMsbBJuelnqyjR7RcwhYGe01j8809ZAFCrCg994Do6B05RaJ4RMiMnTGgOLc3HjWe1FSitROk1TGkVNGRtUA9vFiGZ1wnhNsE8A4BMGFTGbXwrR+ZpMmWQKZNoIERHgPV/IVwnXMeF+VRubkg6V/SoyzkoSWMFmqpELjVyqVFqBaUMpNIQDQ003Z/epHH+Fxl2c6pywoRmz1s+LDplDnizKpBLHSctA8ErFlpZ5sNsNKT/E7GhV1a6OSDf+NO5mkAmExNMWkhpo/cszOmIEYHtGOftUz68JiCkFzDpoqNDzJqERa50FMos15CZgcwMRKuCbWssfuVW+4q3caxzqkHzjJAZOe6OgJSDy/OYzwfIpEHLaxudaJ1pHq5JEQEhgmDUpHPnw1zPsFybaB+beNMGlUIrr+KxpnTR1CH40yaOBYToABmcCb58b8CV2jkRssygqiREuDVhIaSGygyWf7OPq978IQsAP/mNj9M5cApwQjXNL970UbFWFtEFnLqCJwlMKhQGAgoGKolTMxh63NI/KYYhNUi8Z2Gy09qhCai8uaWkQSEr9EyOnnFmZGq6xby+zOCJc5OvGpl/tUEpUzMRhXDu6azQkMqNkRbaXSy0uzj/q5+gqXYKQPOMkBk54UKz1GmhUxXRe/Z0xFekMd4pBw9XGk4j/fxM6OWDtkgH8zKZ8AzaI31XZ9Qx4RwIJkZGx3IEUEgNYyWMdV7BlDhJGydtgS1zXWwp3F/RKrF4+6fsJbcw7OZk5oQLDSGnGidcaO699ibRrXJ0qgKdyi2gUVrl39yUbgbe/8FrAGPFhFAa49/eHB7XyRgpBG/aZMCPOFcjonYySR8/MO4VhdIq5NK5k2NQp5EwRgK+vOBkkMJO1ppx/OReJQhjm4ZyY58w/hGtCuVWg0s+QW1zsnJCvWeBpU4LDeXe5V+q2lgzDayUTXSrHNqK2MCNH7BnMkMmDJbKNgCgZ3N0TYGBVujrDMP5HwFtXBiOtQKVdg25UxUotUJVqjjPElBWoPTzNqVWWNWNeK5b5egMcpRaoSx9nUovzFJiUCl0qjy+YNcvM2gtoau6wFalm/S0ymClX2BrIzga/IUsoAvg0pud4DzwEYbcnEyccE1DCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQk4SxImuwPFg8cu7HgBwyY5zlwAAh5fn4jmr3SNQmQEANJolAGD7/FpMc8nmgwCAHz95LgBgeaUNANCdLKZR7QoA8NLzHgUAPHh4OwBgZa0Z05hSAgBk7q7Vag0AAOdtdfX6+SNnDesVyi5c2mLOpb3i7AMxTbzGcsvl6bo8ohr+rNkZPQDApvkuAODIwwsuTenSmLaOaaW/h8WzDgMA9h/eAgAYHB7egxi4e7D+HubOcs+pkZcxzeH9Lp9aUS6t8ve/qYpptu086tI+7tJKn1b6etnMDp/tCzrumHHnxB73/POjw/u899b3H7e2nB1DmlMe4RteM3M/mlImnrOuDaAoXONpFe7Hn8sHMc2OYsXlz13+buE+e5WMaQp/rJ25fO2G++wN8phGS+Ov7xrEfLMPANjWcI0iK4aNqhwEAdO18ufzfkwT6trJGwCAqnTlWwzrFTqDzf5ah31jt9K3sWL4LJS/Vrj33P8/aA4FC77hIre1OrRSofEN3jTdp/X3K/LhtYrMl+nrZwtXZ+OrbhrDtJtbru7an1zZ5IRY6OF9XvmHn7UAcM/nnn/hkceQhhCSsCE0ja3qnU+qaYzvOaXXAlK4XjETwzThmPKfUvqeUwxNiHCsIV0PKuLxYTlaq9qxWJ6/VijDnfTXUCGN+8yTeo0xoQtsek0QeumYxnf0Irlm5nv9pipr9yeSxxe0BsJzUrpWP/dPSFOvS7gXAGh7zRSO2ZAn1C8xzwINr+mPei2nG8Nz/W3u2OvEGywAfM/e+bxpnA0hNPBmlLHejjdP/zxl0jhzoWv5o7Acw8+SNrihsLn/My88QRDEhPKi8PlrmgkXTYXXJbZj53LfuOM5+fTlDO9zvAEHobZ2QqXD8w3Z5LjwRSEOacI5NX4PbS/4a/3CJfXl26STMN4K3rPr1e7LB+8cr9dzBM0zQmZkQ2ia7KjrvvQETRN7f/+/EHVzaBKhd01Nm2By5bJurtgJxYRjyucp7XjfNap1Yr0wrkXWI/OmqJmkEUbuYRRjpvepoX7BAVDTOEHRqOllR9NP1p+TnaDFo8Lyz2vURAQAk/nftunSLH5plwWAfe++4Tk30zaE0Oy5/rpLAWDhn260GGsMwePkCD9+2sjK4DMdwSbCF/LpkcaZNqYgrJl/6qNjpVTAYiNa574qP0aKjWfCcKfwZlmsx2iBaVsfaV6xPlMELr2HMn2mdvRT1MubZNat07TD8xkVYpu0XqH9Mwye0m3O1X7JLZ+JV/3Fh697TgSI5hkhM7IhNE2grPxkW+oI8N1GHIeOeNEAQI14rEKPKWq99GSdkB4f7cnHyxVjaWX0YHlvldSYSugC0x59Wv3WMcuGpqWvRJo3fB/JbyaYZ6OkXsvwnO2oUybayYnpO1r3CZp1goULANCtpzdhZ2VDCU2YaAxRAAAA5U0H/+802x8TLJvU3Ai5jB311I3/miFf8J7pUa9cLW29PmZS65hmetVMP58m3PuEPKEhB3d7yFNr2OGYLyekPVqNNyUR0obOIbm/bD3X+UgHE+oVJ4qjMCfVCo+lCJ7I8bHR5R91E6D3/cmzmwCleUbIjGwsTbPq/PzpwNbaeo8nJ3jP9EjvHr1nE/qr4D2bbBbV84XeNmqnCfNHQtbrl2pCM6b6QqZxldOPToPpaULZla/Pet65Ua+brmkj/xFNOf+R5AnXmOZkSLX4NPOs5p2zdQ0aTMHUh6MLl/7FNziN87Ndz0zjbCih2ff2GwUALP7Frvi0j8XiDZObo094kju5NHVPW9pQ9MhwJIvu6emTm7EcUc8zOdH4ITViAsaxiB43cbIJ47nReoWZ+yA0Sk4ws+JQqG6epeVkoybbyCRnGj0QhFnr+gMSyf8hwDPE6oV7scnzt94UL+e98Fzvhee22YSH5hkhM7KhNE0ghLcDgG3VB+yhV0t72zBPMzqXkzLaO5sJcxOjRGfBpMH9FNNoUtqx+iSdf+hxe2GgPkHDTKuX9lHEEydovTkWwmGq1OHhrx/NswmaYsw8W6f7DtcI0eFleLapeRZMwBCrN0EDhksab6WHeLVZ2ZhCUyZq3dQbdxzTrGO4TQpkHArb+l6h9FqhQU8SsDFXLEL9ktcaRoUlNMoJM/GDanRMM71+8V5kvdG77z67qptnNS/hFPMsBITWmDJeqbvq3XcdXsWIwphKmq9PNmK+pknCsCd4rL07+oLPfzpebO/7PvC0phrNM0JmZENqGtVLzQT3Odprp+bWtLmb9Tw8k0y4GD8m6x66SZ4kMSEyGNNMuXhj4zFZQWPGkJsYyDWujYJJk42YNqmnzI6oqPUix+3IKwLZqBbAOiE66fzztGjr5P9gCgavWQziTrV3eHQh3s170zIfcgMAF+9yYTcP3jA95IaahpAZ2ZCaJltNgjHjYLc+sJUTXkIbjj3GO6Fpg/o0rR3JH9yug0kBoSPjnImu3ZB09Es6l4N6xMMotfd9pgRsrufMiHlTzTWaPo4lJmij0XdvwnhownhxmGmCMyMM51Q9IqDmLAjHgmIPGj8J7wlDv1e92Y1z7v7b8THOhhSa+24e+uUXv+zmbIJ5ManxT4tyXm+SR68TVh8HoiMR1XUBO7Z7qREaYNKA44tzseAJdktM6z6DJyyaXBPCaOIEZpgQTdZLGAvRqcaFZdTkGr5YNl6vYnRuapKDwhPChvQ6LxrGnzaajYnQ+LKXLp7++9E8I2RGNqSmSZGrTosMchcMuOYHq0uDVkwTQmNWum4VlEHPPTaTLOHUK1z+p3rzrpyemwzod4er0QRTpFLumod6bimpYEJV/USj9dz30POt9twL8U/0NsUka113TIelm/re1Ex666M9V+dOx6WVXZ/Gv7SVvv+z5le1WWk3fX38/fWHfavseS0Ed1/LfZe2HAyfRahHuFZ4MazbLWKalYZ/wb+rfB6vEUv/wmCiKI703G9R9dw1ZcevtdBPzFD/Ps3SQff85xbcklVqbfhMlV9gyAd4RGui3xv+RqgrQLz6jbdZALjrG9c/qyBPQgghhBBCCCGEEEI2Bv8PvOc2oP9DFPIAAAAASUVORK5CYII=" id="image4a9e2e9de9" transform="scale(1 -1) translate(0 -138.96)" x="52" y="-7.04" width="147.6" height="138.96"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 52.30649 145.621635 
+L 52.30649 6.799459 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m8e4a9dd14c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8e4a9dd14c" x="52.30649" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g style="fill: #ffffff" transform="translate(44.354927 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 107.938572 145.621635 
+L 107.938572 6.799459 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8e4a9dd14c" x="107.938572" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.2 -->
+      <g style="fill: #ffffff" transform="translate(99.98701 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 163.570655 145.621635 
+L 163.570655 6.799459 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8e4a9dd14c" x="163.570655" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.4 -->
+      <g style="fill: #ffffff" transform="translate(155.619092 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_4">
+     <!-- $Q$ [1/Å] -->
+     <g style="fill: #ffffff" transform="translate(108.268999 174.920073) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-51" d="M 2309 -84 
+Q 2275 -88 2237 -89 
+Q 2200 -91 2125 -91 
+Q 1250 -91 756 411 
+Q 263 913 263 1797 
+Q 263 2319 452 2844 
+Q 641 3369 978 3788 
+Q 1369 4269 1858 4509 
+Q 2347 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 1928 4265 1147 
+Q 3750 366 2919 44 
+L 3553 -825 
+L 2847 -825 
+L 2309 -84 
+z
+M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c5" d="M 2663 5081 
+Q 2663 5278 2523 5417 
+Q 2384 5556 2188 5556 
+Q 1988 5556 1852 5420 
+Q 1716 5284 1716 5081 
+Q 1716 4884 1853 4746 
+Q 1991 4609 2188 4609 
+Q 2384 4609 2523 4746 
+Q 2663 4884 2663 5081 
+z
+M 2188 4044 
+L 1338 1722 
+L 3041 1722 
+L 2188 4044 
+z
+M 1716 4366 
+Q 1525 4494 1428 4673 
+Q 1331 4853 1331 5081 
+Q 1331 5441 1579 5691 
+Q 1828 5941 2188 5941 
+Q 2544 5941 2795 5689 
+Q 3047 5438 3047 5081 
+Q 3047 4863 2948 4678 
+Q 2850 4494 2663 4366 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1716 4366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(0 0.171875)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(78.710938 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(110.498047 0.171875)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(149.511719 0.171875)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(213.134766 0.171875)"/>
+      <use xlink:href="#DejaVuSans-c5" transform="translate(246.826172 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(315.234375 0.171875)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <defs>
+       <path id="m31b756a161" d="M 0 0 
+L -3.5 0 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.000 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 149.420854) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <path d="M 52.30649 122.484606 
+L 199.731508 122.484606 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="122.484606" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.025 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 126.283824) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_11">
+      <path d="M 52.30649 99.347576 
+L 199.731508 99.347576 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="99.347576" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.050 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 103.146795) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 52.30649 76.210547 
+L 199.731508 76.210547 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="76.210547" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.075 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 80.009766) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_15">
+      <path d="M 52.30649 53.073518 
+L 199.731508 53.073518 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="53.073518" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.100 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 56.872736) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_17">
+      <path d="M 52.30649 29.936488 
+L 199.731508 29.936488 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="29.936488" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.125 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 33.735707) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_19">
+      <path d="M 52.30649 6.799459 
+L 199.731508 6.799459 
+" clip-path="url(#p9d7e79933a)" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m31b756a161" x="52.30649" y="6.799459" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.150 -->
+      <g style="fill: #ffffff" transform="translate(16.678365 10.598677) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- $\theta$ [rad] -->
+     <g style="fill: #ffffff" transform="translate(10.598677 93.060547) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-3b8" d="M 2913 2219 
+L 925 2219 
+Q 791 1284 928 888 
+Q 1100 400 1566 400 
+Q 2034 400 2391 891 
+Q 2703 1322 2913 2219 
+z
+M 3009 2750 
+Q 3094 3638 2984 3950 
+Q 2813 4444 2353 4444 
+Q 1875 4444 1525 3956 
+Q 1250 3563 1034 2750 
+L 3009 2750 
+z
+M 2444 4913 
+Q 3194 4913 3494 4250 
+Q 3794 3591 3566 2422 
+Q 3341 1256 2781 594 
+Q 2225 -72 1475 -72 
+Q 722 -72 425 594 
+Q 128 1256 353 2422 
+Q 581 3591 1134 4250 
+Q 1691 4913 2444 4913 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-3b8" transform="translate(0 0.234375)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(61.181641 0.234375)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(92.96875 0.234375)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(131.982422 0.234375)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(173.095703 0.234375)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(234.375 0.234375)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(297.851562 0.234375)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 52.30649 145.621635 
+L 52.30649 6.799459 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 199.731508 145.621635 
+L 199.731508 6.799459 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 52.30649 6.799459 
+L 199.731508 6.799459 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 207.102759 145.621635 
+L 212.99976 145.621635 
+L 212.99976 6.799459 
+L 207.102759 6.799459 
+L 207.102759 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAgAAADBCAYAAADy6PH3AAABO0lEQVR4nOWY2RXCMAwEddhURgn0XwlgOvDovbXNxW+EZnelgBO/+m3Y5NM8c3bdmnnMCzwcOjACOniABh1h5KIQFCGw4ASCkqRxY1CGw5JnMRAxv17SAIjBHUjDfgQHNScUghpJBTqCVw4QmOSQF4ZtLggKCjCo70DMfwXXbJSOoA4HEAu2WtbwAUkWglIL/iSon3AB3z+0UQtmMT25H3FROEeRyAW/cqqGggsVUZgFiSQNHmoH3abvdwH/aQWRwQjVRchBFQpAQ8bz7Yiw/Qg5yeZqUKihyS4wyQUIOajggu2IZMSDENAheRaAQJFhYLPrLijJAoJmQUGtQKguMAe89brfCYEbhS5UBG7UhRCYA2+UqbPQNwo76Ld/lzvQI0q70KM9dkjq0OFY3AKOQYxoBi+0k942B5zdX4TVeQiTDOWrAAAAAElFTkSuQmCC" id="imageba3e70acfd" transform="scale(1 -1) translate(0 -138.96)" x="207.36" y="-6.48" width="5.76" height="138.96"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_21">
+      <defs>
+       <path id="m9f81d0915c" d="M 0 0 
+L 3.5 0 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9f81d0915c" x="212.99976" y="122.211391" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{-7}}$ -->
+      <g style="fill: #ffffff" transform="translate(219.99976 126.01061) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m9f81d0915c" x="212.99976" y="97.498632" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- $\mathdefault{10^{-4}}$ -->
+      <g style="fill: #ffffff" transform="translate(219.99976 101.297851) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m9f81d0915c" x="212.99976" y="72.785872" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g style="fill: #ffffff" transform="translate(219.99976 76.585091) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m9f81d0915c" x="212.99976" y="48.073112" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g style="fill: #ffffff" transform="translate(219.99976 51.872331) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m9f81d0915c" x="212.99976" y="23.360353" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g style="fill: #ffffff" transform="translate(219.99976 27.159572) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 207.102759 145.621635 
+L 210.05126 145.621635 
+L 212.99976 145.621635 
+L 212.99976 6.799459 
+L 210.05126 6.799459 
+L 207.102759 6.799459 
+L 207.102759 145.621635 
+z
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9d7e79933a">
+   <rect x="52.30649" y="6.799459" width="147.425018" height="138.822176"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/_static/thumbnails/estia_advanced_mcstas_reduction_light.svg
+++ b/docs/_static/thumbnails/estia_advanced_mcstas_reduction_light.svg
@@ -1,0 +1,775 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="216pt" height="180pt" viewBox="0 0 216 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-06-10T13:10:44.276942</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 216 180 
+L 216 0 
+L 0 0 
+L 0 180 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+L 199.731508 6.799459 
+L 52.30649 6.799459 
+L 52.30649 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <g clip-path="url(#p88f8715f7e)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAM0AAADBCAYAAABsfjQSAAAYm0lEQVR4nO2deYwlR33Hv1XV3e+Y2WPWu14feHzbgC0MRhBwUBIh/ooUEUscQiAFSICgKEHBGMfiCI4NeDGHCESKISIJEjgJRgn5IwREohDC2lEICYrB2Mbr9dre9bHHzM7Mu7qrKn/U8arfMd7nY6/5fqTRe9NdVV3dr371+9Wvfl0FEEIIIYQQQgghZMMgwpf7951lF7MWDAwkJPZVXXxr5SW4/orvivWLIGRjIU90BQg51ahpEX3gEhu+L5suDmuN/bqNX7lwD7UNIZ6apunbEtoaaGugIKAEsEN18e0HX2S/9PPX2OnFELJxoHlGyIzUhOYp3UcFDQMLDQsJQMHi3OwoXtV6CP/+0EX2xp9cS41DNjTUNITMSE1ovrb8MqyYAfq2RMdoGH9cQyAXBjtUF+9YuAv/8/AL7IVf/zg1DtmQjHnF/mXPZfaqYhU9a7BiBbQVMD5ZLgy2SSAXEqU12PXUa/DZl32DnjWyoaB5RsiMTNQS9+472zaFxZqRKCGRw0AJi7awKIRAWyhISHyvuxV7Bmfi63tfgf/+9U9S45ANwURNc+fy1VgxKpplJSS0FVgxw+QlNOZkH9vUKt554W6850dv4ziHbAhonhEyI1NNqr974Gp7QX4QChZSWChYNIXGFinQFAqlNfiv/hY8pTdjzTTw2GABhwbz2N/djPsPnol7r72J5ho5LaGmIWRGpgrNmy79sXhcb4aGgLHjSiMXLqvyszm50DijWMVC0cULdzyBy+68ieMbclqyrqb5s0dei6f0JgBAaaUTIH+utO7Nm4FVUDBoyBISFi1VYqHo4przHsIbd7/bvvXud1J4yGkFzTNCZmRdofnOr/2p2DvYjp7NAADaCmhrUVrjM7v5Gw2J0mQwcNEDlZXYVqzh8vkn8LqFn+Gr9/+SveBrdEeT04On1TS/96LvC53M18SMQkAJA20FFAyUcIKUCY2WKgEAbTnAnBzghcUB/PZLduPNu99FwSGnPDTPCJmRYxKaJdPGABLGCmgAJSz61kBbOTTPrAIA9E2G0rjvPZOjKQdQsNiZL+OC9iG8/gfvtS/5xw9T45BTFmoaQmbkmITmrtVLYaxEz2YovY44pAXOy5axVa2htAqlVThSttGQFYwV6JsM2/MV7B3sgIbAwWoTOqbA4twRXL3zUbz+B++1V37rI9Q45JSDmoaQGcmOJdEnr/p78bo9l1kAaIouGkJik9SAX0OgKUo0RBW9Zn2TYV71Y/6m0FjI1tAzuc9j0FAVmjsqnPtvf2Dh3dvPxw0S8lxzzJrmsWoBj1ULKAEYa1FaRFMtOAGMrYfcGCthQiSBfwPUQEAKl3FT3sP25iq2N1edg+D3P0tzjZz00DwjZEZmNonuefgcu0NZLBunFB4oz8C+8gwcLDfhydLFqXV1js1ZDxc3nwQAXNN+ELs7F+NAuRUA0NEFSqswMBl0opkqo6IW+sor/5rmGjkpOaYxTcqyaeAM1YsqKjW9QsSzsdKfGyqyXGhIWH/e5ZH+XR0AaKkBcqHxwtZ+d50fvsd+85dvp+CQkw6aZ4TMyMya5u7uxdih7sEgaBM7lDs9IoO5cB4291qBjGsOaDgHgYFA5tMYK7Al7+KMbBUAcGZjFa/85xvs449sAwDse9cN1DrkpICahpAZmVlornvx98Qh04ju4xQFAwWDyo5qHIPSKjeG8eOaTOo4ppE+fk1biaYo0RQl5rI+drZXsf2cZWw/ZxmLX7mV7mhyUvCMNM3P+2djxRRYMQUMZGzww0Jtbb4m98IUaMgK8IKTHnOvGriycqHRzgbY3Oxhc7OHhR0ruPhvbqbgkBMOzTNCZmRmRwAAvOPyu8UdD7w89vphUK9rL6kNtU2JuiOgMhID4y4dHAGVX4jQjMhxKKPINLZs6uLF//BRe971XQDAdx64jc4Bctx5RkIDAPf3zgYALBYH47HKv0djIFBaFYWo9KZbGM/AC0vlw2/ghcyZZVXtWJjHaWYVSiMxVwyw/EVX3qVHb7IPvPGPKTjkuELzjJAZecZC8/2nLsX3n7oUy3ouBmxmUsfBvYJBLjRyoaFgoWBqHjcpbM17BiCuMxCorEQmDDJhYKxAM6vQzgdYaHax0OziyrMP4Nr/+F06B8hxhZqGkBl5xmOaf33t5wQAXP2/b7DbsjUgGdNoK+LbnIHSZjW3dEgbPnOla+Urr2EC2grk/ns7GwAANmV9XDG/H9nud1sA2PeFy/Cfd3yAYxzyvPKsNc1Pl8/Gim7GxTQmEZaAUsIt9VRaBRmWfPImXTTR4BZbD+UpaaCkQS79WmtiaI01VIWd+TIun38Cl88/gewdT2Dxrz5Jc408r9A8I2RGnrXQfPtXvyAOl3M1UwwjGkF5V3OY7XdzOBLSD/DT6IGBVRhY5R0Ew/PGimiuNVWJpnJrR+eiiuWe2V7BOWcfwUV33GIvuuMWahzyvPCcaJqfHTkLS2UbXZ2jq3MMTIaBydAxBTqmwFHbQMcUcZxTGYW+ydA3WXwlujL1UJzhS2rD490qR2UkOlWBTlX4dBmaskRTlsi8Cddq99Fq92mqkecFmmeEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQggh5LTkuKxG+arvfPAaAD9c7rSwte22yTi82saWuS4OLc9hx9bVmLadl3jpwqP4v6Vz8MiRragqhcGKW3lGtTSkNCi7OVSzwgu2LwEA9t23Exe+6AAe+uk5aJyzBmP84oT3zKO3Q8MWFlAWatktM7X5siM4sn8LRClgMwvZlzBzfoXPSkDMVbjgqwJPvryBe299vwCAxds/ZeVcCXu0gCgF9r6PK3luVLgaDSEzclx6y7fc9TvXAPhh2DYQgF/zTMRFAVuqBADsKFZxZetR7F65BI92tuJIv421gdc00qCZVWhlbrHAxbkjAICr5/biwf5O3Le6E6tlA33tlqheHRSotIKx8J/uds+Y60AIi8cObnUPQVoUhaubFBZFptHIKrTyEhdtcvvvbM56+NGhRRxea2NtrQnddVpLrmYojkjc/7H3U/NsEKhpCJmR4yI0S4MWlgYt9M1wk4JcajRUhYas0JAaSlj/N9zXplBuYfSwCLoUNq6i2c7KWFYh3E7RhaxQyCouY9vMKhSZ0yDW70yQK42tjS4yaSCkhVQGWabjPjlSWAh/HQmLedWPf62sRLsxQLM1gGpXUO0KZr5Cb2eF879wG1fz3CA84602ZuHeR88CAFy1+Gi8Yi41tBXQEMiRbqkhoYSp7dk5Vmnptl0P53Oh3YZRVqKyKq753DcZtJGQAlBeGABACoNcakhpYS2glIkbG0ppYK2A8MIatkDMhYb2+4IqOayvyCystbANg8W/vNXKoxmdBKc5NM8ImZHjomn2vvVDuwGIc797vT2zvQL43j4QthKE38NGon4uELpvCYvMm3FI9r8JhC0KRaJdXFnus1AaK2UT1gJCAMZIyLj/jdMk1muxthzUyoQ39bLMXbvUwpUjLVRu0NjaxRXf+ogFgJ++/mZqnNOQ4yI0gUf2b0P7fNcIM+l2OpPCmVp50ihLm6G0amwbjkBqmsFvyb5aNWL6IICh4Qtv6hkvPwOtUGoFYwSUqg9FtBEoMgPhxzdt5eqb7kyd1sgaASEAlRvkRYVNrR7OnV929fzmx+xg7zweuo7m2ukEzTNCZuS4Cs2+t98oVgYNrAwa6FSF7/2lr4gz0YIjIMVaEbVGurlTQArjvF3JTtEAUBkZ80lhYzmF96IFRwCA6L0L17B+Dinsj9O3WUyX6iahLCDdMSktNhd9FFKjkNpd76w+Lt71GXrWTiOoaQiZkeMuNAceX8CBxxfQrzIMks1tDURtsJ2L4ea1ouYutrV08NsTuugCUxt7ZLKukZS0UNJOHSsFwlxNZWSsVy40hNcySlgYI2KMm5AWSpk4n9RSpftrDKCUQblzgAs+/2lqm9OE4+oIAICHf+tGAQBnfvuPbCOrIIV1cyZJY9d+oF8Z9xnmRyDN8DhE3OczeM/cPI2MQlX5fGHeRZuhqVZqBeHlxlpEISqUqZlncddqXwVtJLQdOhCMsbBJuelnqyjR7RcwhYGe01j8809ZAFCrCg994Do6B05RaJ4RMiMnTGgOLc3HjWe1FSitROk1TGkVNGRtUA9vFiGZ1wnhNsE8A4BMGFTGbXwrR+ZpMmWQKZNoIERHgPV/IVwnXMeF+VRubkg6V/SoyzkoSWMFmqpELjVyqVFqBaUMpNIQDQ003Z/epHH+Fxl2c6pywoRmz1s+LDplDnizKpBLHSctA8ErFlpZ5sNsNKT/E7GhV1a6OSDf+NO5mkAmExNMWkhpo/cszOmIEYHtGOftUz68JiCkFzDpoqNDzJqERa50FMos15CZgcwMRKuCbWssfuVW+4q3caxzqkHzjJAZOe6OgJSDy/OYzwfIpEHLaxudaJ1pHq5JEQEhgmDUpHPnw1zPsFybaB+beNMGlUIrr+KxpnTR1CH40yaOBYToABmcCb58b8CV2jkRssygqiREuDVhIaSGygyWf7OPq978IQsAP/mNj9M5cApwQjXNL970UbFWFtEFnLqCJwlMKhQGAgoGKolTMxh63NI/KYYhNUi8Z2Gy09qhCai8uaWkQSEr9EyOnnFmZGq6xby+zOCJc5OvGpl/tUEpUzMRhXDu6azQkMqNkRbaXSy0uzj/q5+gqXYKQPOMkBk54UKz1GmhUxXRe/Z0xFekMd4pBw9XGk4j/fxM6OWDtkgH8zKZ8AzaI31XZ9Qx4RwIJkZGx3IEUEgNYyWMdV7BlDhJGydtgS1zXWwp3F/RKrF4+6fsJbcw7OZk5oQLDSGnGidcaO699ibRrXJ0qgKdyi2gUVrl39yUbgbe/8FrAGPFhFAa49/eHB7XyRgpBG/aZMCPOFcjonYySR8/MO4VhdIq5NK5k2NQp5EwRgK+vOBkkMJO1ppx/OReJQhjm4ZyY58w/hGtCuVWg0s+QW1zsnJCvWeBpU4LDeXe5V+q2lgzDayUTXSrHNqK2MCNH7BnMkMmDJbKNgCgZ3N0TYGBVujrDMP5HwFtXBiOtQKVdg25UxUotUJVqjjPElBWoPTzNqVWWNWNeK5b5egMcpRaoSx9nUovzFJiUCl0qjy+YNcvM2gtoau6wFalm/S0ymClX2BrIzga/IUsoAvg0pud4DzwEYbcnEyccE1DCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQk4SxImuwPFg8cu7HgBwyY5zlwAAh5fn4jmr3SNQmQEANJolAGD7/FpMc8nmgwCAHz95LgBgeaUNANCdLKZR7QoA8NLzHgUAPHh4OwBgZa0Z05hSAgBk7q7Vag0AAOdtdfX6+SNnDesVyi5c2mLOpb3i7AMxTbzGcsvl6bo8ohr+rNkZPQDApvkuAODIwwsuTenSmLaOaaW/h8WzDgMA9h/eAgAYHB7egxi4e7D+HubOcs+pkZcxzeH9Lp9aUS6t8ve/qYpptu086tI+7tJKn1b6etnMDp/tCzrumHHnxB73/POjw/u899b3H7e2nB1DmlMe4RteM3M/mlImnrOuDaAoXONpFe7Hn8sHMc2OYsXlz13+buE+e5WMaQp/rJ25fO2G++wN8phGS+Ov7xrEfLMPANjWcI0iK4aNqhwEAdO18ufzfkwT6trJGwCAqnTlWwzrFTqDzf5ah31jt9K3sWL4LJS/Vrj33P8/aA4FC77hIre1OrRSofEN3jTdp/X3K/LhtYrMl+nrZwtXZ+OrbhrDtJtbru7an1zZ5IRY6OF9XvmHn7UAcM/nnn/hkceQhhCSsCE0ja3qnU+qaYzvOaXXAlK4XjETwzThmPKfUvqeUwxNiHCsIV0PKuLxYTlaq9qxWJ6/VijDnfTXUCGN+8yTeo0xoQtsek0QeumYxnf0Irlm5nv9pipr9yeSxxe0BsJzUrpWP/dPSFOvS7gXAGh7zRSO2ZAn1C8xzwINr+mPei2nG8Nz/W3u2OvEGywAfM/e+bxpnA0hNPBmlLHejjdP/zxl0jhzoWv5o7Acw8+SNrihsLn/My88QRDEhPKi8PlrmgkXTYXXJbZj53LfuOM5+fTlDO9zvAEHobZ2QqXD8w3Z5LjwRSEOacI5NX4PbS/4a/3CJfXl26STMN4K3rPr1e7LB+8cr9dzBM0zQmZkQ2ia7KjrvvQETRN7f/+/EHVzaBKhd01Nm2By5bJurtgJxYRjyucp7XjfNap1Yr0wrkXWI/OmqJmkEUbuYRRjpvepoX7BAVDTOEHRqOllR9NP1p+TnaDFo8Lyz2vURAQAk/nftunSLH5plwWAfe++4Tk30zaE0Oy5/rpLAWDhn260GGsMwePkCD9+2sjK4DMdwSbCF/LpkcaZNqYgrJl/6qNjpVTAYiNa574qP0aKjWfCcKfwZlmsx2iBaVsfaV6xPlMELr2HMn2mdvRT1MubZNat07TD8xkVYpu0XqH9Mwye0m3O1X7JLZ+JV/3Fh697TgSI5hkhM7IhNE2grPxkW+oI8N1GHIeOeNEAQI14rEKPKWq99GSdkB4f7cnHyxVjaWX0YHlvldSYSugC0x59Wv3WMcuGpqWvRJo3fB/JbyaYZ6OkXsvwnO2oUybayYnpO1r3CZp1goULANCtpzdhZ2VDCU2YaAxRAAAA5U0H/+802x8TLJvU3Ai5jB311I3/miFf8J7pUa9cLW29PmZS65hmetVMP58m3PuEPKEhB3d7yFNr2OGYLyekPVqNNyUR0obOIbm/bD3X+UgHE+oVJ4qjMCfVCo+lCJ7I8bHR5R91E6D3/cmzmwCleUbIjGwsTbPq/PzpwNbaeo8nJ3jP9EjvHr1nE/qr4D2bbBbV84XeNmqnCfNHQtbrl2pCM6b6QqZxldOPToPpaULZla/Pet65Ua+brmkj/xFNOf+R5AnXmOZkSLX4NPOs5p2zdQ0aTMHUh6MLl/7FNziN87Ndz0zjbCih2ff2GwUALP7Frvi0j8XiDZObo094kju5NHVPW9pQ9MhwJIvu6emTm7EcUc8zOdH4ITViAsaxiB43cbIJ47nReoWZ+yA0Sk4ws+JQqG6epeVkoybbyCRnGj0QhFnr+gMSyf8hwDPE6oV7scnzt94UL+e98Fzvhee22YSH5hkhM7KhNE0ghLcDgG3VB+yhV0t72zBPMzqXkzLaO5sJcxOjRGfBpMH9FNNoUtqx+iSdf+hxe2GgPkHDTKuX9lHEEydovTkWwmGq1OHhrx/NswmaYsw8W6f7DtcI0eFleLapeRZMwBCrN0EDhksab6WHeLVZ2ZhCUyZq3dQbdxzTrGO4TQpkHArb+l6h9FqhQU8SsDFXLEL9ktcaRoUlNMoJM/GDanRMM71+8V5kvdG77z67qptnNS/hFPMsBITWmDJeqbvq3XcdXsWIwphKmq9PNmK+pknCsCd4rL07+oLPfzpebO/7PvC0phrNM0JmZENqGtVLzQT3Odprp+bWtLmb9Tw8k0y4GD8m6x66SZ4kMSEyGNNMuXhj4zFZQWPGkJsYyDWujYJJk42YNqmnzI6oqPUix+3IKwLZqBbAOiE66fzztGjr5P9gCgavWQziTrV3eHQh3s170zIfcgMAF+9yYTcP3jA95IaahpAZ2ZCaJltNgjHjYLc+sJUTXkIbjj3GO6Fpg/o0rR3JH9yug0kBoSPjnImu3ZB09Es6l4N6xMMotfd9pgRsrufMiHlTzTWaPo4lJmij0XdvwnhownhxmGmCMyMM51Q9IqDmLAjHgmIPGj8J7wlDv1e92Y1z7v7b8THOhhSa+24e+uUXv+zmbIJ5ManxT4tyXm+SR68TVh8HoiMR1XUBO7Z7qREaYNKA44tzseAJdktM6z6DJyyaXBPCaOIEZpgQTdZLGAvRqcaFZdTkGr5YNl6vYnRuapKDwhPChvQ6LxrGnzaajYnQ+LKXLp7++9E8I2RGNqSmSZGrTosMchcMuOYHq0uDVkwTQmNWum4VlEHPPTaTLOHUK1z+p3rzrpyemwzod4er0QRTpFLumod6bimpYEJV/USj9dz30POt9twL8U/0NsUka113TIelm/re1Ex666M9V+dOx6WVXZ/Gv7SVvv+z5le1WWk3fX38/fWHfavseS0Ed1/LfZe2HAyfRahHuFZ4MazbLWKalYZ/wb+rfB6vEUv/wmCiKI703G9R9dw1ZcevtdBPzFD/Ps3SQff85xbcklVqbfhMlV9gyAd4RGui3xv+RqgrQLz6jbdZALjrG9c/qyBPQgghhBBCCCGEEEI2Bv8PvOc2oP9DFPIAAAAASUVORK5CYII=" id="image6c75b1f22a" transform="scale(1 -1) translate(0 -138.96)" x="52" y="-7.04" width="147.6" height="138.96"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 52.30649 145.621635 
+L 52.30649 6.799459 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mcc06cb542e" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mcc06cb542e" x="52.30649" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(44.354927 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 107.938572 145.621635 
+L 107.938572 6.799459 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mcc06cb542e" x="107.938572" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.2 -->
+      <g transform="translate(99.98701 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 163.570655 145.621635 
+L 163.570655 6.799459 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mcc06cb542e" x="163.570655" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.4 -->
+      <g transform="translate(155.619092 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_4">
+     <!-- $Q$ [1/Å] -->
+     <g transform="translate(108.268999 174.920073) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-51" d="M 2309 -84 
+Q 2275 -88 2237 -89 
+Q 2200 -91 2125 -91 
+Q 1250 -91 756 411 
+Q 263 913 263 1797 
+Q 263 2319 452 2844 
+Q 641 3369 978 3788 
+Q 1369 4269 1858 4509 
+Q 2347 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 1928 4265 1147 
+Q 3750 366 2919 44 
+L 3553 -825 
+L 2847 -825 
+L 2309 -84 
+z
+M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c5" d="M 2663 5081 
+Q 2663 5278 2523 5417 
+Q 2384 5556 2188 5556 
+Q 1988 5556 1852 5420 
+Q 1716 5284 1716 5081 
+Q 1716 4884 1853 4746 
+Q 1991 4609 2188 4609 
+Q 2384 4609 2523 4746 
+Q 2663 4884 2663 5081 
+z
+M 2188 4044 
+L 1338 1722 
+L 3041 1722 
+L 2188 4044 
+z
+M 1716 4366 
+Q 1525 4494 1428 4673 
+Q 1331 4853 1331 5081 
+Q 1331 5441 1579 5691 
+Q 1828 5941 2188 5941 
+Q 2544 5941 2795 5689 
+Q 3047 5438 3047 5081 
+Q 3047 4863 2948 4678 
+Q 2850 4494 2663 4366 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1716 4366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(0 0.171875)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(78.710938 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(110.498047 0.171875)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(149.511719 0.171875)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(213.134766 0.171875)"/>
+      <use xlink:href="#DejaVuSans-c5" transform="translate(246.826172 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(315.234375 0.171875)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <defs>
+       <path id="m204c029f95" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.000 -->
+      <g transform="translate(16.678365 149.420854) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <path d="M 52.30649 122.484606 
+L 199.731508 122.484606 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="122.484606" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.025 -->
+      <g transform="translate(16.678365 126.283824) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_11">
+      <path d="M 52.30649 99.347576 
+L 199.731508 99.347576 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="99.347576" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.050 -->
+      <g transform="translate(16.678365 103.146795) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 52.30649 76.210547 
+L 199.731508 76.210547 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="76.210547" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.075 -->
+      <g transform="translate(16.678365 80.009766) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_15">
+      <path d="M 52.30649 53.073518 
+L 199.731508 53.073518 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="53.073518" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.100 -->
+      <g transform="translate(16.678365 56.872736) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_17">
+      <path d="M 52.30649 29.936488 
+L 199.731508 29.936488 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="29.936488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.125 -->
+      <g transform="translate(16.678365 33.735707) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_19">
+      <path d="M 52.30649 6.799459 
+L 199.731508 6.799459 
+" clip-path="url(#p88f8715f7e)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m204c029f95" x="52.30649" y="6.799459" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.150 -->
+      <g transform="translate(16.678365 10.598677) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- $\theta$ [rad] -->
+     <g transform="translate(10.598677 93.060547) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-3b8" d="M 2913 2219 
+L 925 2219 
+Q 791 1284 928 888 
+Q 1100 400 1566 400 
+Q 2034 400 2391 891 
+Q 2703 1322 2913 2219 
+z
+M 3009 2750 
+Q 3094 3638 2984 3950 
+Q 2813 4444 2353 4444 
+Q 1875 4444 1525 3956 
+Q 1250 3563 1034 2750 
+L 3009 2750 
+z
+M 2444 4913 
+Q 3194 4913 3494 4250 
+Q 3794 3591 3566 2422 
+Q 3341 1256 2781 594 
+Q 2225 -72 1475 -72 
+Q 722 -72 425 594 
+Q 128 1256 353 2422 
+Q 581 3591 1134 4250 
+Q 1691 4913 2444 4913 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-3b8" transform="translate(0 0.234375)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(61.181641 0.234375)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(92.96875 0.234375)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(131.982422 0.234375)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(173.095703 0.234375)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(234.375 0.234375)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(297.851562 0.234375)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 52.30649 145.621635 
+L 52.30649 6.799459 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 199.731508 145.621635 
+L 199.731508 6.799459 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 52.30649 145.621635 
+L 199.731508 145.621635 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 52.30649 6.799459 
+L 199.731508 6.799459 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 207.102759 145.621635 
+L 212.99976 145.621635 
+L 212.99976 6.799459 
+L 207.102759 6.799459 
+L 207.102759 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAgAAADBCAYAAADy6PH3AAABO0lEQVR4nOWY2RXCMAwEddhURgn0XwlgOvDovbXNxW+EZnelgBO/+m3Y5NM8c3bdmnnMCzwcOjACOniABh1h5KIQFCGw4ASCkqRxY1CGw5JnMRAxv17SAIjBHUjDfgQHNScUghpJBTqCVw4QmOSQF4ZtLggKCjCo70DMfwXXbJSOoA4HEAu2WtbwAUkWglIL/iSon3AB3z+0UQtmMT25H3FROEeRyAW/cqqGggsVUZgFiSQNHmoH3abvdwH/aQWRwQjVRchBFQpAQ8bz7Yiw/Qg5yeZqUKihyS4wyQUIOajggu2IZMSDENAheRaAQJFhYLPrLijJAoJmQUGtQKguMAe89brfCYEbhS5UBG7UhRCYA2+UqbPQNwo76Ld/lzvQI0q70KM9dkjq0OFY3AKOQYxoBi+0k942B5zdX4TVeQiTDOWrAAAAAElFTkSuQmCC" id="image52c419f3ac" transform="scale(1 -1) translate(0 -138.96)" x="207.36" y="-6.48" width="5.76" height="138.96"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_21">
+      <defs>
+       <path id="m74edabdb91" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m74edabdb91" x="212.99976" y="122.211391" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{10^{-7}}$ -->
+      <g transform="translate(219.99976 126.01061) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m74edabdb91" x="212.99976" y="97.498632" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- $\mathdefault{10^{-4}}$ -->
+      <g transform="translate(219.99976 101.297851) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m74edabdb91" x="212.99976" y="72.785872" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(219.99976 76.585091) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m74edabdb91" x="212.99976" y="48.073112" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(219.99976 51.872331) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m74edabdb91" x="212.99976" y="23.360353" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(219.99976 27.159572) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 207.102759 145.621635 
+L 210.05126 145.621635 
+L 212.99976 145.621635 
+L 212.99976 6.799459 
+L 210.05126 6.799459 
+L 207.102759 6.799459 
+L 207.102759 145.621635 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p88f8715f7e">
+   <rect x="52.30649" y="6.799459" width="147.425018" height="138.822176"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/_static/thumbnails/estia_mcstas_reduction_dark.svg
+++ b/docs/_static/thumbnails/estia_mcstas_reduction_dark.svg
@@ -1,0 +1,1482 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="216pt" height="180pt" viewBox="0 0 216 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-06-10T13:10:40.148754</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 216 180 
+L 216 0 
+L 0 0 
+L 0 180 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 47.178365 145.621635 
+L 212.99976 145.621635 
+L 212.99976 3.00024 
+L 47.178365 3.00024 
+L 47.178365 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m2194f04548" d="M 0 0 
+L 0 3.5 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2194f04548" x="76.197109" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.2 -->
+      <g style="fill: #ffffff" transform="translate(68.245547 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m2194f04548" x="117.652458" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.3 -->
+      <g style="fill: #ffffff" transform="translate(109.700895 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m2194f04548" x="159.107807" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.4 -->
+      <g style="fill: #ffffff" transform="translate(151.156244 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m2194f04548" x="200.563155" y="145.621635" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.5 -->
+      <g style="fill: #ffffff" transform="translate(192.611593 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- $Q$ [1/Å] -->
+     <g style="fill: #ffffff" transform="translate(112.339063 174.920073) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-51" d="M 2309 -84 
+Q 2275 -88 2237 -89 
+Q 2200 -91 2125 -91 
+Q 1250 -91 756 411 
+Q 263 913 263 1797 
+Q 263 2319 452 2844 
+Q 641 3369 978 3788 
+Q 1369 4269 1858 4509 
+Q 2347 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 1928 4265 1147 
+Q 3750 366 2919 44 
+L 3553 -825 
+L 2847 -825 
+L 2309 -84 
+z
+M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c5" d="M 2663 5081 
+Q 2663 5278 2523 5417 
+Q 2384 5556 2188 5556 
+Q 1988 5556 1852 5420 
+Q 1716 5284 1716 5081 
+Q 1716 4884 1853 4746 
+Q 1991 4609 2188 4609 
+Q 2384 4609 2523 4746 
+Q 2663 4884 2663 5081 
+z
+M 2188 4044 
+L 1338 1722 
+L 3041 1722 
+L 2188 4044 
+z
+M 1716 4366 
+Q 1525 4494 1428 4673 
+Q 1331 4853 1331 5081 
+Q 1331 5441 1579 5691 
+Q 1828 5941 2188 5941 
+Q 2544 5941 2795 5689 
+Q 3047 5438 3047 5081 
+Q 3047 4863 2948 4678 
+Q 2850 4494 2663 4366 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1716 4366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(0 0.171875)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(78.710938 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(110.498047 0.171875)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(149.511719 0.171875)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(213.134766 0.171875)"/>
+      <use xlink:href="#DejaVuSans-c5" transform="translate(246.826172 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(315.234375 0.171875)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="m2adfa230db" d="M 0 0 
+L -3.5 0 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="130.842468" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- $\mathdefault{10^{-6}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 134.641687) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="107.683268" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-5}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 111.482487) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="84.524069" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{-4}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 88.323287) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="61.364869" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 65.164088) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="38.205669" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 42.004888) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2adfa230db" x="47.178365" y="15.046469" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g style="fill: #ffffff" transform="translate(16.678365 18.845688) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_11">
+      <defs>
+       <path id="m6b31cb718c" d="M 0 0 
+L -2 0 
+" style="stroke: #ffffff; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="142.951921" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="140.05844" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="137.814082" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="135.980308" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="134.429874" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="133.086826" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="131.902175" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="123.870854" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="119.792722" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="116.899241" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="114.654882" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="112.821108" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="111.270674" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="109.927627" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="108.742975" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="100.711655" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="96.633522" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="93.740041" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="91.495682" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="89.661908" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="88.111474" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="86.768427" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="85.583775" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="77.552455" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="73.474322" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="70.580841" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="68.336483" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="66.502708" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="64.952274" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="63.609227" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="62.424576" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="54.393255" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="50.315122" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="47.421641" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="45.177283" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="43.343508" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="41.793074" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="40.450027" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="39.265376" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="31.234055" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="27.155923" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="24.262441" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="22.018083" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="20.184309" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="18.633875" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="17.290828" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="16.106176" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="8.074855" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m6b31cb718c" x="47.178365" y="3.996723" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- $R(Q)$ -->
+     <g style="fill: #ffffff" transform="translate(10.598678 85.660938) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(0 0.125)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(69.482422 0.125)"/>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(108.496094 0.125)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(187.207031 0.125)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_60">
+    <path d="M 56.199828 77.387511 
+L 57.793776 77.387511 
+L 57.793776 59.008118 
+L 59.387724 59.008118 
+L 59.387724 88.026864 
+L 60.981672 88.026864 
+L 60.981672 103.991654 
+L 62.57562 103.991654 
+L 62.57562 97.893446 
+L 64.169568 97.893446 
+L 64.169568 89.631499 
+L 65.763516 89.631499 
+L 65.763516 84.237204 
+L 67.357464 84.237204 
+L 67.357464 74.006756 
+L 68.951412 74.006756 
+L 68.951412 62.579832 
+L 70.545361 62.579832 
+L 70.545361 24.350162 
+L 72.139309 24.350162 
+L 72.139309 40.437213 
+L 73.733257 40.437213 
+L 73.733257 73.357807 
+L 75.327205 73.357807 
+L 75.327205 85.735515 
+L 76.921153 85.735515 
+L 76.921153 98.867515 
+L 78.515101 98.867515 
+L 78.515101 110.092102 
+L 80.109049 110.092102 
+L 80.109049 104.814469 
+L 81.702997 104.814469 
+L 81.702997 87.141433 
+L 83.296945 87.141433 
+L 83.296945 45.515151 
+L 84.890893 45.515151 
+L 84.890893 46.262932 
+L 86.484841 46.262932 
+L 86.484841 84.22224 
+L 88.078789 84.22224 
+L 88.078789 95.244476 
+L 89.672737 95.244476 
+L 89.672737 101.540935 
+L 91.266685 101.540935 
+L 91.266685 102.712844 
+L 92.860633 102.712844 
+L 92.860633 98.243055 
+L 94.454581 98.243055 
+L 94.454581 88.379587 
+L 96.048529 88.379587 
+L 96.048529 56.235358 
+L 97.642477 56.235358 
+L 97.642477 45.759441 
+L 99.236426 45.759441 
+L 99.236426 90.228239 
+L 100.830374 90.228239 
+L 100.830374 105.853859 
+L 102.424322 105.853859 
+L 102.424322 118.538725 
+L 104.01827 118.538725 
+L 104.01827 114.985433 
+L 105.612218 114.985433 
+L 105.612218 103.333753 
+L 107.206166 103.333753 
+L 107.206166 90.720777 
+L 108.800114 90.720777 
+L 108.800114 66.124231 
+L 110.394062 66.124231 
+L 110.394062 43.530781 
+L 111.98801 43.530781 
+L 111.98801 80.595359 
+L 113.581958 80.595359 
+L 113.581958 97.334256 
+L 115.175906 97.334256 
+L 115.175906 110.147428 
+L 116.769854 110.147428 
+L 116.769854 121.225416 
+L 118.363802 121.225416 
+L 118.363802 130.522352 
+L 119.95775 130.522352 
+L 119.95775 122.54221 
+L 121.551698 122.54221 
+L 121.551698 98.967352 
+L 123.145646 98.967352 
+L 123.145646 66.195373 
+L 124.739594 66.195373 
+L 124.739594 98.743558 
+L 126.333543 98.743558 
+L 126.333543 124.764012 
+L 127.927491 124.764012 
+L 127.927491 132.472916 
+L 129.521439 132.472916 
+L 129.521439 125.626838 
+L 131.115387 125.626838 
+L 131.115387 117.716486 
+L 132.709335 117.716486 
+L 132.709335 105.591721 
+L 134.303283 105.591721 
+L 134.303283 88.158761 
+L 135.897231 88.158761 
+L 135.897231 52.152137 
+L 137.491179 52.152137 
+L 137.491179 76.160492 
+L 139.085127 76.160492 
+L 139.085127 102.223795 
+L 140.679075 102.223795 
+L 140.679075 116.795552 
+L 142.273023 116.795552 
+L 142.273023 126.157352 
+L 143.866971 126.157352 
+L 143.866971 127.708786 
+L 145.460919 127.708786 
+L 145.460919 119.179524 
+L 147.054867 119.179524 
+L 147.054867 103.975204 
+L 148.648815 103.975204 
+L 148.648815 62.27457 
+L 150.242763 62.27457 
+L 150.242763 76.499487 
+L 151.836711 76.499487 
+L 151.836711 110.75256 
+L 153.43066 110.75256 
+L 153.43066 125.687192 
+L 155.024608 125.687192 
+L 155.024608 133.854355 
+L 156.618556 133.854355 
+L 156.618556 132.147842 
+L 158.212504 132.147842 
+L 158.212504 122.545278 
+L 159.806452 122.545278 
+L 159.806452 109.552862 
+L 161.4004 109.552862 
+L 161.4004 70.8357 
+L 162.994348 70.8357 
+L 162.994348 73.779884 
+L 164.588296 73.779884 
+L 164.588296 109.666377 
+L 166.182244 109.666377 
+L 166.182244 125.120624 
+L 167.776192 125.120624 
+L 167.776192 131.270021 
+L 169.37014 131.270021 
+L 169.37014 132.167122 
+L 170.964088 132.167122 
+L 170.964088 124.029544 
+L 172.558036 124.029544 
+L 172.558036 112.189934 
+L 174.151984 112.189934 
+L 174.151984 76.977865 
+L 175.745932 76.977865 
+L 175.745932 68.111235 
+L 177.33988 68.111235 
+L 177.33988 106.100722 
+L 178.933828 106.100722 
+L 178.933828 122.553078 
+L 180.527776 122.553078 
+L 180.527776 129.189439 
+L 182.121725 129.189439 
+L 182.121725 136.505995 
+L 183.715673 136.505995 
+L 183.715673 134.946874 
+L 185.309621 134.946874 
+L 185.309621 120.760897 
+L 186.903569 120.760897 
+L 186.903569 89.460368 
+L 188.497517 89.460368 
+L 188.497517 75.915475 
+L 190.091465 75.915475 
+L 190.091465 118.598514 
+L 191.685413 118.598514 
+L 191.685413 125.255893 
+L 193.279361 125.255893 
+L 193.279361 138.438399 
+L 194.873309 138.438399 
+L 194.873309 133.133516 
+L 196.467257 133.133516 
+L 196.467257 124.809403 
+L 198.061205 124.809403 
+L 198.061205 120.383284 
+L 199.655153 120.383284 
+L 199.655153 101.795933 
+L 201.249101 101.795933 
+L 201.249101 68.213416 
+L 202.843049 68.213416 
+L 202.843049 57.070049 
+L 204.436997 57.070049 
+L 204.436997 12.892933 
+L 206.030945 12.892933 
+L 206.030945 12.892933 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="LineCollection_1">
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 56.996802 78.625019 
+L 56.996802 76.285719 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 58.59075 59.584018 
+L 58.59075 58.463414 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 60.184698 88.870116 
+L 60.184698 87.248875 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 61.778646 104.234338 
+L 61.778646 103.754689 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 63.372594 98.094719 
+L 63.372594 97.696123 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 64.966542 89.81992 
+L 64.966542 89.446542 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 66.56049 84.413865 
+L 66.56049 84.063593 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 68.154438 74.188237 
+L 68.154438 73.828491 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 69.748386 62.766976 
+L 69.748386 62.396106 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 71.342335 24.566353 
+L 71.342335 24.138521 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 72.936283 40.831685 
+L 72.936283 40.057631 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 74.530231 73.548961 
+L 74.530231 73.170219 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 76.124179 85.93355 
+L 76.124179 85.541304 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 77.718127 99.070474 
+L 77.718127 98.66857 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 79.312075 110.284312 
+L 79.312075 109.903497 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 80.906023 105.019263 
+L 80.906023 104.613762 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 82.499971 87.376363 
+L 82.499971 86.911866 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 84.093919 45.81715 
+L 84.093919 45.221956 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 85.687867 46.604767 
+L 85.687867 45.932334 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 87.281815 84.460486 
+L 87.281815 83.989507 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 88.875763 95.464437 
+L 88.875763 95.029222 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 90.469711 101.755388 
+L 90.469711 101.33096 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 92.063659 102.929606 
+L 92.063659 102.500656 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 93.657607 98.466274 
+L 93.657607 98.024682 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 95.251555 88.623802 
+L 95.251555 88.141162 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 96.845503 56.65185 
+L 96.845503 55.835429 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 98.439452 46.073692 
+L 98.439452 45.454712 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 100.0334 90.50284 
+L 100.0334 89.960936 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 101.627348 106.155727 
+L 101.627348 105.560786 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 103.221296 118.766517 
+L 103.221296 118.315979 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 104.815244 115.250787 
+L 104.815244 114.726899 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 106.409192 103.599386 
+L 106.409192 103.074954 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 108.00314 91.005712 
+L 108.00314 90.443691 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 109.597088 66.723647 
+L 109.597088 65.558537 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 111.191036 43.842796 
+L 111.191036 43.228156 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 112.784984 80.923865 
+L 112.784984 80.277244 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 114.378932 97.620982 
+L 114.378932 97.055478 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 115.97288 110.456445 
+L 115.97288 109.847623 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 117.566828 121.513511 
+L 117.566828 120.945343 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 119.160776 130.779514 
+L 119.160776 130.271601 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 120.754724 122.873232 
+L 120.754724 122.221736 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 122.348672 99.472584 
+L 122.348672 98.486289 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 123.94262 66.53192 
+L 123.94262 65.869723 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 125.536569 99.419095 
+L 125.536569 98.110552 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 127.130517 125.123318 
+L 127.130517 124.4171 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 128.724465 132.784131 
+L 128.724465 132.171043 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 130.318413 125.957634 
+L 130.318413 125.306576 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 131.912361 118.044294 
+L 131.912361 117.399026 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 133.506309 105.94005 
+L 133.506309 105.255053 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 135.100257 88.56279 
+L 135.100257 87.770337 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 136.694205 52.548688 
+L 136.694205 51.77063 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 138.288153 76.993565 
+L 138.288153 75.391174 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 139.882101 102.570975 
+L 139.882101 101.8882 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 141.476049 117.135672 
+L 141.476049 116.466558 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 143.069997 126.491049 
+L 143.069997 125.834373 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 144.663945 128.012785 
+L 144.663945 127.413706 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 146.257893 119.551427 
+L 146.257893 118.820883 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 147.851841 104.404879 
+L 147.851841 103.563136 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 149.445789 62.758672 
+L 149.445789 61.812702 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 151.039737 77.215835 
+L 151.039737 75.830785 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 152.633685 111.14112 
+L 152.633685 110.378454 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 154.227634 126.104236 
+L 154.227634 125.286754 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 155.821582 134.196496 
+L 155.821582 133.523471 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 157.41553 132.517301 
+L 157.41553 131.791476 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 159.009478 122.926824 
+L 159.009478 122.177679 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 160.603426 110.020649 
+L 160.603426 109.105868 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 162.197374 71.431552 
+L 162.197374 70.273181 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 163.791322 74.380017 
+L 163.791322 73.213552 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 165.38527 110.122883 
+L 165.38527 109.229695 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 166.979218 125.512656 
+L 166.979218 124.743301 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 168.573166 131.641651 
+L 168.573166 130.911634 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 170.167114 132.551678 
+L 170.167114 131.796729 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 171.761062 124.452469 
+L 171.761062 123.623688 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 173.35501 112.673867 
+L 173.35501 111.72822 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 174.948958 77.822417 
+L 174.948958 76.198767 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 176.542906 68.695961 
+L 176.542906 67.558642 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 178.136854 106.601706 
+L 178.136854 105.623513 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 179.730802 123.025962 
+L 179.730802 122.101432 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 181.324751 129.693134 
+L 181.324751 128.70977 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 182.918699 137.005373 
+L 182.918699 136.030244 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 184.512647 135.5085 
+L 184.512647 134.414957 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 186.106595 121.401351 
+L 186.106595 120.158794 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 187.700543 90.816844 
+L 187.700543 88.265284 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 189.294491 76.635305 
+L 189.294491 75.24374 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 190.888439 119.293981 
+L 190.888439 117.948041 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 192.482387 126.214106 
+L 192.482387 124.381081 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 194.076335 139.138844 
+L 194.076335 137.783573 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 195.670283 133.995294 
+L 195.670283 132.339784 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 197.264231 125.915347 
+L 197.264231 123.813108 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 198.858179 121.493082 
+L 198.858179 119.383863 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 200.452127 103.525916 
+L 200.452127 100.320297 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 202.046075 70.144024 
+L 202.046075 66.594382 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 203.640023 62.229636 
+L 203.640023 53.676534 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path d="M 205.233971 18.09098 
+L 205.233971 9.483031 
+" clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+    <path clip-path="url(#p2ae3e01c08)" style="fill: none; stroke: #8dd3c7; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 47.178365 145.621635 
+L 47.178365 3.00024 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 212.99976 145.621635 
+L 212.99976 3.00024 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 47.178365 145.621635 
+L 212.99976 145.621635 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 47.178365 3.00024 
+L 212.99976 3.00024 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2ae3e01c08">
+   <rect x="47.178365" y="3.00024" width="165.821395" height="142.621395"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/_static/thumbnails/estia_mcstas_reduction_light.svg
+++ b/docs/_static/thumbnails/estia_mcstas_reduction_light.svg
@@ -1,0 +1,1482 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="216pt" height="180pt" viewBox="0 0 216 180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-06-10T13:10:39.360461</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 180 
+L 216 180 
+L 216 0 
+L 0 0 
+L 0 180 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 47.178365 145.621635 
+L 212.99976 145.621635 
+L 212.99976 3.00024 
+L 47.178365 3.00024 
+L 47.178365 145.621635 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m37c71f53f6" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m37c71f53f6" x="76.197109" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.2 -->
+      <g transform="translate(68.245547 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m37c71f53f6" x="117.652458" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.3 -->
+      <g transform="translate(109.700895 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m37c71f53f6" x="159.107807" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.4 -->
+      <g transform="translate(151.156244 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m37c71f53f6" x="200.563155" y="145.621635" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.5 -->
+      <g transform="translate(192.611593 160.220073) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- $Q$ [1/Å] -->
+     <g transform="translate(112.339063 174.920073) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-51" d="M 2309 -84 
+Q 2275 -88 2237 -89 
+Q 2200 -91 2125 -91 
+Q 1250 -91 756 411 
+Q 263 913 263 1797 
+Q 263 2319 452 2844 
+Q 641 3369 978 3788 
+Q 1369 4269 1858 4509 
+Q 2347 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 1928 4265 1147 
+Q 3750 366 2919 44 
+L 3553 -825 
+L 2847 -825 
+L 2309 -84 
+z
+M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c5" d="M 2663 5081 
+Q 2663 5278 2523 5417 
+Q 2384 5556 2188 5556 
+Q 1988 5556 1852 5420 
+Q 1716 5284 1716 5081 
+Q 1716 4884 1853 4746 
+Q 1991 4609 2188 4609 
+Q 2384 4609 2523 4746 
+Q 2663 4884 2663 5081 
+z
+M 2188 4044 
+L 1338 1722 
+L 3041 1722 
+L 2188 4044 
+z
+M 1716 4366 
+Q 1525 4494 1428 4673 
+Q 1331 4853 1331 5081 
+Q 1331 5441 1579 5691 
+Q 1828 5941 2188 5941 
+Q 2544 5941 2795 5689 
+Q 3047 5438 3047 5081 
+Q 3047 4863 2948 4678 
+Q 2850 4494 2663 4366 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1716 4366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(0 0.171875)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(78.710938 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(110.498047 0.171875)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(149.511719 0.171875)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(213.134766 0.171875)"/>
+      <use xlink:href="#DejaVuSans-c5" transform="translate(246.826172 0.171875)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(315.234375 0.171875)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="m91ec4fa7de" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="130.842468" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- $\mathdefault{10^{-6}}$ -->
+      <g transform="translate(16.678365 134.641687) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="107.683268" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{-5}}$ -->
+      <g transform="translate(16.678365 111.482487) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="84.524069" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{-4}}$ -->
+      <g transform="translate(16.678365 88.323287) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="61.364869" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{-3}}$ -->
+      <g transform="translate(16.678365 65.164088) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="38.205669" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{-2}}$ -->
+      <g transform="translate(16.678365 42.004888) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 39.046875) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(186.855469 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m91ec4fa7de" x="47.178365" y="15.046469" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(16.678365 18.845688) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_11">
+      <defs>
+       <path id="m9417b8248e" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="142.951921" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="140.05844" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="137.814082" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="135.980308" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="134.429874" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="133.086826" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="131.902175" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="123.870854" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="119.792722" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="116.899241" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="114.654882" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="112.821108" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="111.270674" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="109.927627" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="108.742975" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="100.711655" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="96.633522" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="93.740041" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="91.495682" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="89.661908" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="88.111474" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="86.768427" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="85.583775" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="77.552455" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="73.474322" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="70.580841" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="68.336483" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="66.502708" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="64.952274" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="63.609227" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="62.424576" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="54.393255" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="50.315122" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="47.421641" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="45.177283" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="43.343508" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="41.793074" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="40.450027" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="39.265376" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="31.234055" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="27.155923" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="24.262441" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="22.018083" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="20.184309" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="18.633875" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="17.290828" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="16.106176" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="8.074855" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m9417b8248e" x="47.178365" y="3.996723" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- $R(Q)$ -->
+     <g transform="translate(10.598678 85.660938) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(0 0.125)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(69.482422 0.125)"/>
+      <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(108.496094 0.125)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(187.207031 0.125)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_60">
+    <path d="M 56.199828 77.387511 
+L 57.793776 77.387511 
+L 57.793776 59.008118 
+L 59.387724 59.008118 
+L 59.387724 88.026864 
+L 60.981672 88.026864 
+L 60.981672 103.991654 
+L 62.57562 103.991654 
+L 62.57562 97.893446 
+L 64.169568 97.893446 
+L 64.169568 89.631499 
+L 65.763516 89.631499 
+L 65.763516 84.237204 
+L 67.357464 84.237204 
+L 67.357464 74.006756 
+L 68.951412 74.006756 
+L 68.951412 62.579832 
+L 70.545361 62.579832 
+L 70.545361 24.350162 
+L 72.139309 24.350162 
+L 72.139309 40.437213 
+L 73.733257 40.437213 
+L 73.733257 73.357807 
+L 75.327205 73.357807 
+L 75.327205 85.735515 
+L 76.921153 85.735515 
+L 76.921153 98.867515 
+L 78.515101 98.867515 
+L 78.515101 110.092102 
+L 80.109049 110.092102 
+L 80.109049 104.814469 
+L 81.702997 104.814469 
+L 81.702997 87.141433 
+L 83.296945 87.141433 
+L 83.296945 45.515151 
+L 84.890893 45.515151 
+L 84.890893 46.262932 
+L 86.484841 46.262932 
+L 86.484841 84.22224 
+L 88.078789 84.22224 
+L 88.078789 95.244476 
+L 89.672737 95.244476 
+L 89.672737 101.540935 
+L 91.266685 101.540935 
+L 91.266685 102.712844 
+L 92.860633 102.712844 
+L 92.860633 98.243055 
+L 94.454581 98.243055 
+L 94.454581 88.379587 
+L 96.048529 88.379587 
+L 96.048529 56.235358 
+L 97.642477 56.235358 
+L 97.642477 45.759441 
+L 99.236426 45.759441 
+L 99.236426 90.228239 
+L 100.830374 90.228239 
+L 100.830374 105.853859 
+L 102.424322 105.853859 
+L 102.424322 118.538725 
+L 104.01827 118.538725 
+L 104.01827 114.985433 
+L 105.612218 114.985433 
+L 105.612218 103.333753 
+L 107.206166 103.333753 
+L 107.206166 90.720777 
+L 108.800114 90.720777 
+L 108.800114 66.124231 
+L 110.394062 66.124231 
+L 110.394062 43.530781 
+L 111.98801 43.530781 
+L 111.98801 80.595359 
+L 113.581958 80.595359 
+L 113.581958 97.334256 
+L 115.175906 97.334256 
+L 115.175906 110.147428 
+L 116.769854 110.147428 
+L 116.769854 121.225416 
+L 118.363802 121.225416 
+L 118.363802 130.522352 
+L 119.95775 130.522352 
+L 119.95775 122.54221 
+L 121.551698 122.54221 
+L 121.551698 98.967352 
+L 123.145646 98.967352 
+L 123.145646 66.195373 
+L 124.739594 66.195373 
+L 124.739594 98.743558 
+L 126.333543 98.743558 
+L 126.333543 124.764012 
+L 127.927491 124.764012 
+L 127.927491 132.472916 
+L 129.521439 132.472916 
+L 129.521439 125.626838 
+L 131.115387 125.626838 
+L 131.115387 117.716486 
+L 132.709335 117.716486 
+L 132.709335 105.591721 
+L 134.303283 105.591721 
+L 134.303283 88.158761 
+L 135.897231 88.158761 
+L 135.897231 52.152137 
+L 137.491179 52.152137 
+L 137.491179 76.160492 
+L 139.085127 76.160492 
+L 139.085127 102.223795 
+L 140.679075 102.223795 
+L 140.679075 116.795552 
+L 142.273023 116.795552 
+L 142.273023 126.157352 
+L 143.866971 126.157352 
+L 143.866971 127.708786 
+L 145.460919 127.708786 
+L 145.460919 119.179524 
+L 147.054867 119.179524 
+L 147.054867 103.975204 
+L 148.648815 103.975204 
+L 148.648815 62.27457 
+L 150.242763 62.27457 
+L 150.242763 76.499487 
+L 151.836711 76.499487 
+L 151.836711 110.75256 
+L 153.43066 110.75256 
+L 153.43066 125.687192 
+L 155.024608 125.687192 
+L 155.024608 133.854355 
+L 156.618556 133.854355 
+L 156.618556 132.147842 
+L 158.212504 132.147842 
+L 158.212504 122.545278 
+L 159.806452 122.545278 
+L 159.806452 109.552862 
+L 161.4004 109.552862 
+L 161.4004 70.8357 
+L 162.994348 70.8357 
+L 162.994348 73.779884 
+L 164.588296 73.779884 
+L 164.588296 109.666377 
+L 166.182244 109.666377 
+L 166.182244 125.120624 
+L 167.776192 125.120624 
+L 167.776192 131.270021 
+L 169.37014 131.270021 
+L 169.37014 132.167122 
+L 170.964088 132.167122 
+L 170.964088 124.029544 
+L 172.558036 124.029544 
+L 172.558036 112.189934 
+L 174.151984 112.189934 
+L 174.151984 76.977865 
+L 175.745932 76.977865 
+L 175.745932 68.111235 
+L 177.33988 68.111235 
+L 177.33988 106.100722 
+L 178.933828 106.100722 
+L 178.933828 122.553078 
+L 180.527776 122.553078 
+L 180.527776 129.189439 
+L 182.121725 129.189439 
+L 182.121725 136.505995 
+L 183.715673 136.505995 
+L 183.715673 134.946874 
+L 185.309621 134.946874 
+L 185.309621 120.760897 
+L 186.903569 120.760897 
+L 186.903569 89.460368 
+L 188.497517 89.460368 
+L 188.497517 75.915475 
+L 190.091465 75.915475 
+L 190.091465 118.598514 
+L 191.685413 118.598514 
+L 191.685413 125.255893 
+L 193.279361 125.255893 
+L 193.279361 138.438399 
+L 194.873309 138.438399 
+L 194.873309 133.133516 
+L 196.467257 133.133516 
+L 196.467257 124.809403 
+L 198.061205 124.809403 
+L 198.061205 120.383284 
+L 199.655153 120.383284 
+L 199.655153 101.795933 
+L 201.249101 101.795933 
+L 201.249101 68.213416 
+L 202.843049 68.213416 
+L 202.843049 57.070049 
+L 204.436997 57.070049 
+L 204.436997 12.892933 
+L 206.030945 12.892933 
+L 206.030945 12.892933 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="LineCollection_1">
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 56.996802 78.625019 
+L 56.996802 76.285719 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 58.59075 59.584018 
+L 58.59075 58.463414 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 60.184698 88.870116 
+L 60.184698 87.248875 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 61.778646 104.234338 
+L 61.778646 103.754689 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 63.372594 98.094719 
+L 63.372594 97.696123 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 64.966542 89.81992 
+L 64.966542 89.446542 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 66.56049 84.413865 
+L 66.56049 84.063593 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 68.154438 74.188237 
+L 68.154438 73.828491 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 69.748386 62.766976 
+L 69.748386 62.396106 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 71.342335 24.566353 
+L 71.342335 24.138521 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 72.936283 40.831685 
+L 72.936283 40.057631 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 74.530231 73.548961 
+L 74.530231 73.170219 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 76.124179 85.93355 
+L 76.124179 85.541304 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 77.718127 99.070474 
+L 77.718127 98.66857 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 79.312075 110.284312 
+L 79.312075 109.903497 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 80.906023 105.019263 
+L 80.906023 104.613762 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 82.499971 87.376363 
+L 82.499971 86.911866 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 84.093919 45.81715 
+L 84.093919 45.221956 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 85.687867 46.604767 
+L 85.687867 45.932334 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 87.281815 84.460486 
+L 87.281815 83.989507 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 88.875763 95.464437 
+L 88.875763 95.029222 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 90.469711 101.755388 
+L 90.469711 101.33096 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 92.063659 102.929606 
+L 92.063659 102.500656 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 93.657607 98.466274 
+L 93.657607 98.024682 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 95.251555 88.623802 
+L 95.251555 88.141162 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 96.845503 56.65185 
+L 96.845503 55.835429 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 98.439452 46.073692 
+L 98.439452 45.454712 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 100.0334 90.50284 
+L 100.0334 89.960936 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 101.627348 106.155727 
+L 101.627348 105.560786 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 103.221296 118.766517 
+L 103.221296 118.315979 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 104.815244 115.250787 
+L 104.815244 114.726899 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 106.409192 103.599386 
+L 106.409192 103.074954 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 108.00314 91.005712 
+L 108.00314 90.443691 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 109.597088 66.723647 
+L 109.597088 65.558537 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 111.191036 43.842796 
+L 111.191036 43.228156 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 112.784984 80.923865 
+L 112.784984 80.277244 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 114.378932 97.620982 
+L 114.378932 97.055478 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 115.97288 110.456445 
+L 115.97288 109.847623 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 117.566828 121.513511 
+L 117.566828 120.945343 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 119.160776 130.779514 
+L 119.160776 130.271601 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 120.754724 122.873232 
+L 120.754724 122.221736 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 122.348672 99.472584 
+L 122.348672 98.486289 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 123.94262 66.53192 
+L 123.94262 65.869723 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 125.536569 99.419095 
+L 125.536569 98.110552 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 127.130517 125.123318 
+L 127.130517 124.4171 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 128.724465 132.784131 
+L 128.724465 132.171043 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 130.318413 125.957634 
+L 130.318413 125.306576 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 131.912361 118.044294 
+L 131.912361 117.399026 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 133.506309 105.94005 
+L 133.506309 105.255053 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 135.100257 88.56279 
+L 135.100257 87.770337 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 136.694205 52.548688 
+L 136.694205 51.77063 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 138.288153 76.993565 
+L 138.288153 75.391174 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 139.882101 102.570975 
+L 139.882101 101.8882 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 141.476049 117.135672 
+L 141.476049 116.466558 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 143.069997 126.491049 
+L 143.069997 125.834373 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 144.663945 128.012785 
+L 144.663945 127.413706 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 146.257893 119.551427 
+L 146.257893 118.820883 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 147.851841 104.404879 
+L 147.851841 103.563136 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 149.445789 62.758672 
+L 149.445789 61.812702 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 151.039737 77.215835 
+L 151.039737 75.830785 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 152.633685 111.14112 
+L 152.633685 110.378454 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 154.227634 126.104236 
+L 154.227634 125.286754 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 155.821582 134.196496 
+L 155.821582 133.523471 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 157.41553 132.517301 
+L 157.41553 131.791476 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 159.009478 122.926824 
+L 159.009478 122.177679 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 160.603426 110.020649 
+L 160.603426 109.105868 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 162.197374 71.431552 
+L 162.197374 70.273181 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 163.791322 74.380017 
+L 163.791322 73.213552 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 165.38527 110.122883 
+L 165.38527 109.229695 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 166.979218 125.512656 
+L 166.979218 124.743301 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 168.573166 131.641651 
+L 168.573166 130.911634 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 170.167114 132.551678 
+L 170.167114 131.796729 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 171.761062 124.452469 
+L 171.761062 123.623688 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 173.35501 112.673867 
+L 173.35501 111.72822 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 174.948958 77.822417 
+L 174.948958 76.198767 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 176.542906 68.695961 
+L 176.542906 67.558642 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 178.136854 106.601706 
+L 178.136854 105.623513 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 179.730802 123.025962 
+L 179.730802 122.101432 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 181.324751 129.693134 
+L 181.324751 128.70977 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 182.918699 137.005373 
+L 182.918699 136.030244 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 184.512647 135.5085 
+L 184.512647 134.414957 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 186.106595 121.401351 
+L 186.106595 120.158794 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 187.700543 90.816844 
+L 187.700543 88.265284 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 189.294491 76.635305 
+L 189.294491 75.24374 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 190.888439 119.293981 
+L 190.888439 117.948041 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 192.482387 126.214106 
+L 192.482387 124.381081 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 194.076335 139.138844 
+L 194.076335 137.783573 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 195.670283 133.995294 
+L 195.670283 132.339784 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 197.264231 125.915347 
+L 197.264231 123.813108 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 198.858179 121.493082 
+L 198.858179 119.383863 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 200.452127 103.525916 
+L 200.452127 100.320297 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 202.046075 70.144024 
+L 202.046075 66.594382 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 203.640023 62.229636 
+L 203.640023 53.676534 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 205.233971 18.09098 
+L 205.233971 9.483031 
+" clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path clip-path="url(#p2776966c8d)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 47.178365 145.621635 
+L 47.178365 3.00024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 212.99976 145.621635 
+L 212.99976 3.00024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 47.178365 145.621635 
+L 212.99976 145.621635 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 47.178365 3.00024 
+L 212.99976 3.00024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2776966c8d">
+   <rect x="47.178365" y="3.00024" width="165.821395" height="142.621395"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,23 +28,26 @@
   </br></br>
 </div>
 
-## Overview
+## Quick links
 
-This documentation is under construction.
-See the [Amor data reduction](examples/amor) example for a quick start.
+::::{grid} 3
 
-## Table of contents
+:::{grid-item-card} ESTIA
+:link: user-guide/estia/index.md
 
-```{toctree}
----
-maxdepth: 2
----
+:::
 
-user-guide/index
-api-reference/index
-developer/index
-about/index
-```
+:::{grid-item-card} Amor
+:link: user-guide/amor/index.md
+
+:::
+
+::::{grid-item-card} Offspec
+:link: user-guide/offspec/index.md
+
+:::
+
+::::
 
 :::{include} user-guide/installation.md
 :heading-offset: 1
@@ -54,3 +57,14 @@ about/index
 
 - If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/essreflectometry/discussions). Please include a self-contained reproducible example if possible.
 - Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/essreflectometry).
+
+```{toctree}
+---
+hidden:
+---
+
+user-guide/index
+api-reference/index
+developer/index
+about/index
+```

--- a/docs/user-guide/amor/index.md
+++ b/docs/user-guide/amor/index.md
@@ -6,4 +6,5 @@ maxdepth: 1
 ---
 amor-reduction
 compare-to-eos
+workflow-widget
 ```

--- a/docs/user-guide/amor/workflow-widget.ipynb
+++ b/docs/user-guide/amor/workflow-widget.ipynb
@@ -1,9 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Workflow widget"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,12 +42,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
     "gui = AmorBatchReductionGUI()\n",
-    "gui.widget\n"
+    "gui.widget"
    ]
   }
  ],

--- a/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
@@ -1,0 +1,436 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# ESTIA advanced data reduction\n",
+    "\n",
+    "- Audience: Instrument (data) scientists, instrument users\n",
+    "- Prerequisites: Basic knowledge of [Scipp](https://scipp.github.io/), [Sciline](https://scipp.github.io/sciline/)\n",
+    "\n",
+    "This notebook builds on the [basic ESTIA reduction guide](./estia-mcstas-reduction.rst); you should read that first.\n",
+    "This advanced guide demonstrates how the workflow can be used to make diagnostics plots and options for processing multiple files together.\n",
+    "e the default loader with the `load_mcstas_events` provider.\n",
+    "\n",
+    "The data is available through the ESSreflectometry package but accessing it requires the pooch package.\n",
+    "If you get an error about a missing module pooch, you can install it with `!pip install pooch`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import NewType\n",
+    "\n",
+    "import pandas as pd\n",
+    "import sciline\n",
+    "import scipp as sc\n",
+    "\n",
+    "from ess.estia.data import estia_mcstas_example, estia_mcstas_groundtruth\n",
+    "from ess.estia import EstiaMcStasWorkflow\n",
+    "from ess.reflectometry.types import *\n",
+    "from ess.reflectometry.figures import wavelength_z_figure, wavelength_theta_figure, q_theta_figure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Process multiple files\n",
+    "\n",
+    "To apply the ESTIA workflow to multiple files, we could simply write a for-loop like this:\n",
+    "```python\n",
+    "results = []\n",
+    "for filename in estia_mcstas_example('Ni/Ti-multilayer'):\n",
+    "    wf[Filename[SampleRun]] = filename\n",
+    "    results.append(wf.compute(ReflectivityOverQ))\n",
+    "```\n",
+    "However, this would re-load and re-process the reference measurement for every sample file.\n",
+    "Instead, we will use Sciline's [map-reduce](https://scipp.github.io/sciline/user-guide/parameter-tables.html) feature to map the workflow over several files and merge the individual results.\n",
+    "\n",
+    "First, we set up the workflow in almost the same way as in the [basic ESTIA reduction guide](./estia-mcstas-reduction.rst), except that we do *not* set a filename for the sample run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wf = EstiaMcStasWorkflow()\n",
+    "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
+    "\n",
+    "wf[YIndexLimits] = sc.scalar(35), sc.scalar(64)\n",
+    "wf[ZIndexLimits] = sc.scalar(0), sc.scalar(48 * 32)\n",
+    "wf[BeamDivergenceLimits] = sc.scalar(-0.75, unit='deg'), sc.scalar(0.75, unit='deg')\n",
+    "\n",
+    "wf[WavelengthBins] = sc.geomspace('wavelength', 3.5, 12, 2001, unit='angstrom')\n",
+    "wf[QBins] = 1000\n",
+    "\n",
+    "# There is no proton current data in the McStas files, here we just add some fake proton current\n",
+    "# data to make the workflow run.\n",
+    "wf[ProtonCurrent[SampleRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})\n",
+    "wf[ProtonCurrent[ReferenceRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "### Reflectivity vs. Q\n",
+    "\n",
+    "The data is very noisy in some $Q$ bins.\n",
+    "We can mask those bins based on the variance of the reference measurement to improve the plot or the reflectivity.\n",
+    "Note that this step is entirely optional!\n",
+    "We need to apply the mask as part of the workflow so we have access to the reference data.\n",
+    "It is not easily accessible once we map the workflow over files.\n",
+    "So we define a custom type (`MaskedReflectivityOverQ`) and a provider to apply the mask:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MaskedReflectivityOverQ = NewType('MaskedReflectivityOverQ', sc.DataArray)\n",
+    "\n",
+    "def mask_noisy_reference(\n",
+    "    reflectivity: ReflectivityOverQ,\n",
+    "    reference: Reference,\n",
+    ") -> MaskedReflectivityOverQ:\n",
+    "    ref = reference.hist(Q=reflectivity.coords['Q'])\n",
+    "    return reflectivity.assign_masks(\n",
+    "        noisy_reference= sc.stddevs(ref).data > 0.3 * ref.data\n",
+    "    )\n",
+    "\n",
+    "wf.insert(mask_noisy_reference)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "We need a function to merge the individual measurements in the 'reduce' step.\n",
+    "In this case, we simply combine them into a data group.\n",
+    "We use the sample rotation as key because in this example, each file contains data at a different rotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def combine_measurements(*measurements: sc.DataArray) -> sc.DataGroup[sc.DataArray]:\n",
+    "    return sc.DataGroup({\n",
+    "        f\"{da.coords['sample_rotation']:c}\": da for da in measurements\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Now we are ready to perform the map-reduce operations.\n",
+    "We do this in our custom-defined `MaskedReflectivityOverQ` type.\n",
+    "But we could just as well use `ReflectivityOverQ` if we didn't want the mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_file_workflow = wf.copy()\n",
+    "param_table = pd.DataFrame({\n",
+    "    Filename[SampleRun]: estia_mcstas_example('Ni/Ti-multilayer')\n",
+    "}).rename_axis(index='run')\n",
+    "mapped = multi_file_workflow[MaskedReflectivityOverQ].map(param_table)\n",
+    "multi_file_workflow[MaskedReflectivityOverQ] = mapped.reduce(\n",
+    "    func=combine_measurements\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "The graph now indicates that everything that depends on `SampleRun` data has been mapped: (Names shown in boxes as opposed to rectangles have been mapped.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_file_workflow.visualize(\n",
+    "    MaskedReflectivityOverQ,\n",
+    "    graph_attr={\"rankdir\": \"LR\"},\n",
+    "    compact=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "We compute the reflectivity for each file and get a data group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivities = multi_file_workflow.compute(MaskedReflectivityOverQ)\n",
+    "reflectivities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "To plot, we histogram and set values in masked bins to NaN to make the plot easier to read:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histograms = reflectivities.hist().apply(lambda R: R.assign(\n",
+    "    sc.where(\n",
+    "        R.masks['noisy_reference'],\n",
+    "        sc.scalar(float('nan'), unit=R.unit),\n",
+    "        R.data\n",
+    "    )\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "Since this data is from a McStas simulation, we know the true reflectivity of the sample.\n",
+    "We plot it alongside the 'measured' reflectivity for comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ground_truth = estia_mcstas_groundtruth('Ni/Ti-multilayer')\n",
+    "sc.plot({'ground_truth': ground_truth} | dict(histograms), norm='log', vmin=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "### Other projections\n",
+    "\n",
+    "ESSreflectometry provides functions for plotting the intensity as a function of different variables.\n",
+    "Note that these plots can also be produced by the workflow directly, see [Draw diagnostics plots with the workflow](#Draw-diagnostics-plots-with-the-workflow).\n",
+    "But here, we make them manually to more easily combine data from all files.\n",
+    "\n",
+    "The plots consume data that is provided by the `Sample` key in the workflow.\n",
+    "We could map-reduce the workflow in that key instead of in `MaskedReflectivityOverQ` to compute `Sample` for each file.\n",
+    "But for simplicity, we use [sciline.compute_mapped](https://scipp.github.io/sciline/generated/functions/sciline.compute_mapped.html#sciline.compute_mapped) to compute the results for all files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = list(sciline.compute_mapped(multi_file_workflow, Sample))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength_z_figure(results[3], wavelength_bins=400)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength_theta_figure(\n",
+    "    results,\n",
+    "    wavelength_bins=200,\n",
+    "    theta_bins=200,\n",
+    "    q_edges_to_display=[sc.scalar(0.016, unit='1/angstrom'), sc.scalar(0.19, unit='1/angstrom')]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q_theta_figure(results, q_bins=200, theta_bins=200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "## Draw diagnostics plots with the workflow\n",
+    "\n",
+    "The ESTIA workflow can produce a number of plots directly to quickly visualize the data in different forms.\n",
+    "Those plots can be combined into a single `ReflectivityDiagnosticsView` or constructed separately.\n",
+    "Here, we use the combined `ReflectivityDiagnosticsView` but you can also request one or more of the individual views (see also the graph below):\n",
+    "- `ReflectivityOverQ`\n",
+    "- `ReflectivityOverZW`\n",
+    "- `WavelengthThetaFigure`\n",
+    "- `WavelengthZIndexFigure`\n",
+    "\n",
+    "These plots correspond to the figures in the [Other projections](#Other-projections) sections above but show only data from a single file.\n",
+    "\n",
+    "We construct the workflow as in the [basic ESTIA reduction guide](./estia-mcstas-reduction.rst) but also add `ThetaBins` for the sample run to control the plots:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wf = EstiaMcStasWorkflow()\n",
+    "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[3]\n",
+    "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
+    "\n",
+    "wf[YIndexLimits] = sc.scalar(35), sc.scalar(64)\n",
+    "wf[ZIndexLimits] = sc.scalar(0), sc.scalar(48 * 32)\n",
+    "wf[BeamDivergenceLimits] = sc.scalar(-0.75, unit='deg'), sc.scalar(0.75, unit='deg')\n",
+    "\n",
+    "wf[WavelengthBins] = sc.geomspace('wavelength', 3.5, 12, 2001, unit='angstrom')\n",
+    "wf[ThetaBins[SampleRun]] = 200\n",
+    "wf[QBins] = 1000\n",
+    "\n",
+    "# There is no proton current data in the McStas files, here we just add some fake proton current\n",
+    "# data to make the workflow run.\n",
+    "wf[ProtonCurrent[SampleRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})\n",
+    "wf[ProtonCurrent[ReferenceRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wf.visualize(ReflectivityDiagnosticsView, graph_attr={'rankdir':'LR'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "We request the figure like any other data in the workflow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view = wf.compute(ReflectivityDiagnosticsView)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28",
+   "metadata": {},
+   "source": [
+    "And finally, we draw it: (this `view` object can be rendered in a Jupyter notebook.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "param_table = pd.DataFrame({\n",
     "    Filename[SampleRun]: estia_mcstas_example('Ni/Ti-multilayer')\n",
-    "}).rename_axis(index='run')\n",
+    "}).rename_axis(index='sample_rotation')\n",
     "\n",
     "# Make a copy to preserve the original `wf`.\n",
     "multi_file_workflow = wf.copy()\n",

--- a/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-advanced-mcstas-reduction.ipynb
@@ -89,20 +89,128 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "### Reflectivity vs. Q\n",
+    "## Reflectivity vs. Q\n",
     "\n",
-    "The data is very noisy in some $Q$ bins.\n",
-    "We can mask those bins based on the variance of the reference measurement to improve the plot or the reflectivity.\n",
-    "Note that this step is entirely optional!\n",
-    "We need to apply the mask as part of the workflow so we have access to the reference data.\n",
-    "It is not easily accessible once we map the workflow over files.\n",
-    "So we define a custom type (`MaskedReflectivityOverQ`) and a provider to apply the mask:"
+    "In this section, we compute the reflectivity as a function of momentum transfer for a number of files with the same sample at different sample rotations.\n",
+    "We will `map` the workflow over the ames for each file and `reduce` the results into a single data group.\n",
+    "\n",
+    "Starting with a parameter table of filenames, we `map` the workflow:\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param_table = pd.DataFrame({\n",
+    "    Filename[SampleRun]: estia_mcstas_example('Ni/Ti-multilayer')\n",
+    "}).rename_axis(index='run')\n",
+    "\n",
+    "# Make a copy to preserve the original `wf`.\n",
+    "multi_file_workflow = wf.copy()\n",
+    "mapped = multi_file_workflow[ReflectivityOverQ].map(param_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "Then we merge the reflectivity data for all files into a single data group.\n",
+    "We use the sample rotation as key because in this example, each file contains data at a different rotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def combine_measurements(*measurements: sc.DataArray) -> sc.DataGroup[sc.DataArray]:\n",
+    "    return sc.DataGroup({\n",
+    "        f\"{da.coords['sample_rotation']:c}\": da for da in measurements\n",
+    "    })\n",
+    "\n",
+    "multi_file_workflow[ReflectivityOverQ] = mapped.reduce(\n",
+    "    func=combine_measurements\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "The graph now indicates that everything that depends on `SampleRun` data has been mapped: (Names shown in boxes as opposed to rectangles have been mapped.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_file_workflow.visualize(\n",
+    "    ReflectivityOverQ,\n",
+    "    graph_attr={\"rankdir\": \"LR\"},\n",
+    "    compact=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "We compute the reflectivity for each file and get a data group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivities = multi_file_workflow.compute(ReflectivityOverQ)\n",
+    "reflectivities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivities.hist().plot(norm='log', vmin=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Reflectivity vs. Q with custom mask\n",
+    "\n",
+    "The data is very noisy in some $Q$ bins.\n",
+    "We can clean up the plot by removing or masking those bins.\n",
+    "The variance of the reference measurement is a good measure for how noisy the final data will be, so we use that to insert a mask into the reflectivity curve.\n",
+    "This means that we need to request `Reference` to construct the mask.\n",
+    "But since the value of `Reference` is different for each sample run, we need to insert a new step into the workflow and include it in the `map`-operation.\n",
+    "See also [Replacing providers](https://scipp.github.io/sciline/recipes/replacing-providers.html) for a more general guide.\n",
+    "\n",
+    "We define a custom type (`MaskedReflectivityOverQ`) and a provider to apply the mask:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,41 +230,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "15",
    "metadata": {},
    "source": [
-    "We need a function to merge the individual measurements in the 'reduce' step.\n",
-    "In this case, we simply combine them into a data group.\n",
-    "We use the sample rotation as key because in this example, each file contains data at a different rotation."
+    "Note that the code above inserts into `wf`, i.e., the unmapped workflow.\n",
+    "Now map-reduce the workflow again but in the new `MaskedReflectivityOverQ` type:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def combine_measurements(*measurements: sc.DataArray) -> sc.DataGroup[sc.DataArray]:\n",
-    "    return sc.DataGroup({\n",
-    "        f\"{da.coords['sample_rotation']:c}\": da for da in measurements\n",
-    "    })"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8",
-   "metadata": {},
-   "source": [
-    "Now we are ready to perform the map-reduce operations.\n",
-    "We do this in our custom-defined `MaskedReflectivityOverQ` type.\n",
-    "But we could just as well use `ReflectivityOverQ` if we didn't want the mask."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,16 +256,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "17",
    "metadata": {},
    "source": [
-    "The graph now indicates that everything that depends on `SampleRun` data has been mapped: (Names shown in boxes as opposed to rectangles have been mapped.)"
+    "The graph is the same as before except that only `MaskedReflectivityOverQ` is available as a final, unmapped type:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,16 +278,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "19",
    "metadata": {},
    "source": [
-    "We compute the reflectivity for each file and get a data group:"
+    "Compute the results:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "21",
    "metadata": {},
    "source": [
     "To plot, we histogram and set values in masked bins to NaN to make the plot easier to read:"
@@ -222,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "23",
    "metadata": {},
    "source": [
     "Since this data is from a McStas simulation, we know the true reflectivity of the sample.\n",
@@ -247,17 +331,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
     "ground_truth = estia_mcstas_groundtruth('Ni/Ti-multilayer')\n",
-    "sc.plot({'ground_truth': ground_truth} | dict(histograms), norm='log', vmin=1e-8)"
+    "sc.plot({'ground_truth': ground_truth} | dict(histograms), norm='log', vmin=1e-8, c={'ground_truth': 'k'})"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Other projections\n",
@@ -274,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Draw diagnostics plots with the workflow\n",
@@ -339,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "33",
    "metadata": {},
    "source": [
     "We request the figure like any other data in the workflow:"
@@ -386,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "35",
    "metadata": {},
    "source": [
     "And finally, we draw it: (this `view` object can be rendered in a Jupyter notebook.)"
@@ -404,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/user-guide/estia/estia-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-mcstas-reduction.ipynb
@@ -5,60 +5,83 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Reduction of ESTIA McStas data"
+    "# Reduction of ESTIA McStas data\n",
+    "\n",
+    "- Audience: Instrument users, beginners\n",
+    "- Prerequisites: Basic knowledge of [Scipp](https://scipp.github.io/)\n",
+    "\n",
+    "This notebook demonstrates the basic reflectometry data reduction workflow for ESTIA with simulated data.\n",
+    "A workflow for data recorded at ESS would be very similar but is not yet available.\n",
+    "The workflow:\n",
+    "\n",
+    "1. Converts the data to momentum transfer $Q$.\n",
+    "2. Normalizes by a reference measurement.\n",
+    "3. Packages the results to be saved to and [ORSO ORT](https://www.reflectometry.org/advanced_and_expert_level/file_format) file.\n",
+    "\n",
+    "The data is available through the ESSreflectometry package but accessing it requires the pooch package.\n",
+    "If you get an error about a missing module pooch, you can install it with `!pip install pooch`."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1",
    "metadata": {},
-   "source": [
-    "This notebook demonstrates how to run the data reduction on the output of McStas simulations of the instrument.\n",
-    "\n",
-    "Essentially this looks very similar to how one would do data reduction on real data files from the physical instrument,\n",
-    "but we replace the default loader with the `load_mcstas_events` provider."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2",
-   "metadata": {},
    "outputs": [],
    "source": [
-    "#%matplotlib widget\n",
     "import scipp as sc\n",
     "\n",
-    "from ess.estia.load import load_mcstas_events\n",
-    "from ess.estia.data import estia_mcstas_example, estia_mcstas_groundtruth\n",
+    "from ess.estia.data import estia_mcstas_example\n",
     "from ess.estia import EstiaMcStasWorkflow\n",
-    "from ess.reflectometry.types import *\n",
-    "from ess.reflectometry.figures import wavelength_z_figure, wavelength_theta_figure, q_theta_figure"
+    "from ess.reflectometry.types import *"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "2",
    "metadata": {},
    "source": [
-    "The Estia reduction workflow is created and we set parameters such as region of interest, wavelengthbins, and q-bins."
+    "## Create and configure the workflow\n",
+    "\n",
+    "We begin by creating the ESTIA (McStas) workflow object which is a skeleton for reducing ESTIA data with pre-configured steps:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "wf = EstiaMcStasWorkflow()\n",
-    "wf.insert(load_mcstas_events)\n",
+    "wf = EstiaMcStasWorkflow()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "We then need to set the missing parameters which are specific to each experiment (the keys are types defined in [ess.reflectometry.types](../../generated/modules/ess.reflectometry.types.rst))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify input data files:\n",
+    "# (The choice of the 2nd 'Ni/Ti-multilayer' file is arbitrary.)\n",
+    "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[2]\n",
     "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
     "\n",
-    "wf[YIndexLimits]  = sc.scalar(35), sc.scalar(64)\n",
+    "# Select a region of interest:\n",
+    "wf[YIndexLimits] = sc.scalar(35), sc.scalar(64)\n",
     "wf[ZIndexLimits] = sc.scalar(0), sc.scalar(48 * 32)\n",
     "wf[BeamDivergenceLimits] = sc.scalar(-0.75, unit='deg'), sc.scalar(0.75, unit='deg')\n",
+    "\n",
+    "# Configure the binning of intermediate and final results:\n",
     "wf[WavelengthBins] = sc.geomspace('wavelength', 3.5, 12, 2001, unit='angstrom')\n",
     "wf[QBins] = 1000\n",
     "\n",
@@ -69,29 +92,7 @@
     "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})\n",
     "wf[ProtonCurrent[ReferenceRun]] = sc.DataArray(\n",
     "    sc.array(dims=('time',), values=[]),\n",
-    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})\n",
-    "\n",
-    "\n",
-    "def compute_reflectivity_curve_for_mcstas_data(wf, results):\n",
-    "    R, ref, da = w.compute((ReflectivityOverQ, Reference, ReducibleData[SampleRun])).values()\n",
-    "    # In the McStas simulation the reference has quite low intensity.\n",
-    "    # To make the reflectivity curve a bit more clean\n",
-    "    # we filter out the Q-points where the reference has too large uncertainties.\n",
-    "    ref = ref.hist(Q=R.coords['Q'])\n",
-    "    too_large_uncertainty_in_reference = sc.stddevs(ref).data > 0.3 * ref.data\n",
-    "    R = R.hist()\n",
-    "    R.data = sc.where(too_large_uncertainty_in_reference, sc.scalar(float('nan'), unit=R.unit), R.data)\n",
-    "    results[f\"{da.coords['sample_rotation'].value} {da.coords['sample_rotation'].unit}\"] = R\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wf.visualize(graph_attr={'rankdir':\"LR\"})"
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})"
    ]
   },
   {
@@ -99,10 +100,9 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "## Ni/Ti multilayer sample\n",
-    "\n",
-    "Below is a comparison between the reflectivity curve obtained using the reduction workflow and the ground truth reflectivity curve that was used in the McStas simulation.\n",
-    "The sample was simulated at different sample rotation settings, each settings produces a separate reflectivity curve covering a higher Q-range, and that is the angle in the legend of the figure."
+    "We can visualize the workflow as a graph.\n",
+    "This can help us understand how the data will be reduced.\n",
+    "(`ReflectivityOverQ` is the key of the output data.)"
    ]
   },
   {
@@ -112,15 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = {}\n",
-    "for path in estia_mcstas_example('Ni/Ti-multilayer'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    compute_reflectivity_curve_for_mcstas_data(w, results)\n",
-    "\n",
-    "ground_truth = estia_mcstas_groundtruth('Ni/Ti-multilayer')\n",
-    "\n",
-    "sc.plot({'ground_truth': ground_truth} | results, norm='log', vmin=1e-8)"
+    "wf.visualize(ReflectivityOverQ, graph_attr={'rankdir': \"LR\"})"
    ]
   },
   {
@@ -128,7 +120,12 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "Below are a number of figures displaying different projections of the measured intensity distribution."
+    "The workflow is a [Sciline](https://scipp.github.io/sciline/) pipeline.\n",
+    "See the documentation of Sciline for more information and how to modify and extend the workflow.\n",
+    "\n",
+    "## Use the reduction workflow\n",
+    "\n",
+    "We call [wf.compute(targets)](https://scipp.github.io/sciline/generated/classes/sciline.Pipeline.html#sciline.Pipeline.compute) to compute the result:"
    ]
   },
   {
@@ -138,21 +135,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = []\n",
-    "for path in estia_mcstas_example('Ni/Ti-multilayer'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    results.append(w.compute(Sample))"
+    "reflectivity = wf.compute(ReflectivityOverQ)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "10",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "wavelength_z_figure(results[3], wavelength_bins=400)"
+    "The reflectivity is still event data.\n",
+    "We can histogram it and plot it:"
    ]
   },
   {
@@ -162,25 +154,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wavelength_theta_figure(results, wavelength_bins=400, theta_bins=200, q_edges_to_display=[sc.scalar(0.016, unit='1/angstrom'), sc.scalar(0.19, unit='1/angstrom')])"
+    "reflectivity.hist().plot(norm='log', vmin=1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Saving to ORSO ORT file\n",
+    "\n",
+    "Ultimately, we want to save the reduced data to a file.\n",
+    "The workflow supports building an [ORSO dataset](https://www.reflectometry.org/orsopy/orsopy.fileio.html#orsopy.fileio.OrsoDataset) from the reduced data: `OrsoIofQDataset`.\n",
+    "We require some additional imports:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
-    "q_theta_figure(results, q_bins=300, theta_bins=200)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13",
-   "metadata": {},
-   "source": [
-    "## Ni on Silicon"
+    "from orsopy import fileio\n",
+    "\n",
+    "from ess.reflectometry import orso"
    ]
   },
   {
@@ -190,28 +188,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = {}\n",
-    "for path in estia_mcstas_example('Ni-film on silicon'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    compute_reflectivity_curve_for_mcstas_data(w, results)\n",
-    "\n",
-    "ground_truth = estia_mcstas_groundtruth('Ni-film on silicon')\n",
-    "sc.plot({'ground_truth': ground_truth} | results, norm='log', vmin=1e-9)"
+    "wf.visualize(orso.OrsoIofQDataset, graph_attr={'rankdir': \"LR\"})"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "15",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "results = []\n",
-    "for path in estia_mcstas_example('Ni-film on silicon'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    results.append(w.compute(ReducibleData[SampleRun]))"
+    "We can see from the graph that some nodes are missing (red boxes).\n",
+    "These need to be manually provided as they cannot be deduced from the input.\n",
+    "Further, McStas files do not contain all required metadata, so that needs to be provided manually as well."
    ]
   },
   {
@@ -221,17 +208,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wavelength_z_figure(results[3], wavelength_bins=400)"
+    "wf[orso.Beamline] = orso.Beamline(name='ESTIA', facility='ESS')\n",
+    "wf[orso.Measurement] = orso.Measurement(\n",
+    "    title='McStas Simulation, Ni/Ti-multilayer',\n",
+    ")\n",
+    "wf[orso.OrsoSample] = orso.OrsoSample(\n",
+    "    fileio.data_source.Sample(name='Ni/Ti multilayer')\n",
+    ")\n",
+    "wf[orso.OrsoCreator] = orso.OrsoCreator(\n",
+    "    fileio.base.Person(\n",
+    "        name='Max Mustermann',\n",
+    "        affiliation='European Spallation Source ERIC',\n",
+    "        contact='max.mustermann@ess.eu',\n",
+    "    )\n",
+    ")\n",
+    "wf[orso.OrsoOwner] = wf[orso.OrsoCreator]"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "17",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "wavelength_theta_figure(results, wavelength_bins=400, theta_bins=200, q_edges_to_display=[sc.scalar(0.016, unit='1/angstrom'), sc.scalar(0.19, unit='1/angstrom')])"
+    "Now that we have these additional parameters, we can construct the ORSO dataset:\n",
+    "(Note that this will re-run the reduction procedure to ensure that all data is consistent.)"
    ]
   },
   {
@@ -241,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q_theta_figure(results, q_bins=300, theta_bins=200)"
+    "dataset = wf.compute(orso.OrsoIofQDataset)"
    ]
   },
   {
@@ -249,7 +249,8 @@
    "id": "19",
    "metadata": {},
    "source": [
-    "## SiO2 on Silicon"
+    "The `dataset` has not been written to disk yet.\n",
+    "For that, simply call `save`:"
    ]
   },
   {
@@ -259,58 +260,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = {}\n",
-    "for path in estia_mcstas_example('Natural SiO2 on silicon'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    compute_reflectivity_curve_for_mcstas_data(w, results)\n",
-    "\n",
-    "ground_truth = estia_mcstas_groundtruth('Natural SiO2 on silicon')\n",
-    "sc.plot({'ground_truth': ground_truth} | results, norm='log', vmin=1e-9)"
+    "dataset.save('estia_reduced_iofq.ort')"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "results = []\n",
-    "for path in estia_mcstas_example('Natural SiO2 on silicon'):\n",
-    "    w = wf.copy()\n",
-    "    w[Filename[SampleRun]] = path\n",
-    "    results.append(w.compute(ReducibleData[SampleRun]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wavelength_z_figure(results[3], wavelength_bins=400)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wavelength_theta_figure(results, wavelength_bins=400, theta_bins=200, q_edges_to_display=[sc.scalar(0.016, unit='1/angstrom')])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "24",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "q_theta_figure(results, q_bins=300, theta_bins=200)"
+    "---\n",
+    "\n",
+    "Next, consider reading the [ESTIA advanced data reduction](./estia-advanced-data-reduction.rst) guide which demonstrates how intermediate results can be inspected and how multiple files can be reduced together."
    ]
   }
  ],

--- a/docs/user-guide/estia/estia-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-mcstas-reduction.ipynb
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "# Specify input data files:\n",
-    "# (The choice of the 2nd 'Ni/Ti-multilayer' file is arbitrary.)\n",
+    "# (The choice of 'Ni/Ti-multilayer' file number 3 is arbitrary.)\n",
     "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[3]\n",
     "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
     "\n",

--- a/docs/user-guide/estia/estia-mcstas-reduction.ipynb
+++ b/docs/user-guide/estia/estia-mcstas-reduction.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "# Specify input data files:\n",
     "# (The choice of the 2nd 'Ni/Ti-multilayer' file is arbitrary.)\n",
-    "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[2]\n",
+    "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[3]\n",
     "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
     "\n",
     "# Select a region of interest:\n",
@@ -270,7 +270,7 @@
    "source": [
     "---\n",
     "\n",
-    "Next, consider reading the [ESTIA advanced data reduction](./estia-advanced-data-reduction.rst) guide which demonstrates how intermediate results can be inspected and how multiple files can be reduced together."
+    "Next, consider reading the [ESTIA advanced McStas reduction](./estia-advanced-mcstas-reduction.rst) guide which demonstrates how multiple files can be reduced together and how to make different types of plots."
    ]
   }
  ],

--- a/docs/user-guide/estia/index.md
+++ b/docs/user-guide/estia/index.md
@@ -1,8 +1,44 @@
-# Estia
+# ESTIA
+
+## Reduction Workflows
+
+::::{grid} 3
+
+:::{grid-item-card} Reduction of McStas Data
+:link: estia-mcstas-reduction.ipynb
+:text-align: center
+
+```{image} ../../_static/thumbnails/estia_mcstas_reduction.svg
+:class: only-light
+:width: 75%
+```
+```{image} ../../_static/thumbnails/estia_mcstas_reduction.svg
+:class: only-dark
+:width: 75%
+```
+:::
+
+:::{grid-item-card} Advanced reduction of McStas Data
+:link: estia-advanced-mcstas-reduction.ipynb
+:text-align: center
+
+```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction.svg
+:class: only-light
+:width: 75%
+```
+```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction.svg
+:class: only-dark
+:width: 75%
+```
+:::
+
+::::
 
 ```{toctree}
 ---
-maxdepth: 1
+hidden:
 ---
+
 estia-mcstas-reduction
+estia-advanced-mcstas-reduction
 ```

--- a/docs/user-guide/estia/index.md
+++ b/docs/user-guide/estia/index.md
@@ -8,13 +8,13 @@
 :link: estia-mcstas-reduction.ipynb
 :text-align: center
 
-```{image} ../../_static/thumbnails/estia_mcstas_reduction.svg
+```{image} ../../_static/thumbnails/estia_mcstas_reduction_light.svg
 :class: only-light
-:width: 75%
+:width: 100%
 ```
-```{image} ../../_static/thumbnails/estia_mcstas_reduction.svg
+```{image} ../../_static/thumbnails/estia_mcstas_reduction_dark.svg
 :class: only-dark
-:width: 75%
+:width: 100%
 ```
 :::
 
@@ -22,13 +22,13 @@
 :link: estia-advanced-mcstas-reduction.ipynb
 :text-align: center
 
-```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction.svg
+```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction_light.svg
 :class: only-light
-:width: 75%
+:width: 100%
 ```
-```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction.svg
+```{image} ../../_static/thumbnails/estia_advanced_mcstas_reduction_dark.svg
 :class: only-dark
-:width: 75%
+:width: 100%
 ```
 :::
 

--- a/src/ess/estia/workflow.py
+++ b/src/ess/estia/workflow.py
@@ -27,6 +27,7 @@ _general_providers = (
 mcstas_providers = (
     *_general_providers,
     *load.providers,
+    load.load_mcstas_events,
 )
 """List of providers for setting up a Sciline pipeline for McStas data.
 

--- a/tools/docs/estia-thumbnails.ipynb
+++ b/tools/docs/estia-thumbnails.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# ESTIA thumbnails\n",
+    "\n",
+    "This notebook generates the thumbnails used in the ESTIA user guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import NewType\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import sciline\n",
+    "import scipp as sc\n",
+    "\n",
+    "from ess.estia.data import estia_mcstas_example\n",
+    "from ess.estia import EstiaMcStasWorkflow\n",
+    "from ess.reflectometry.types import *\n",
+    "from ess.reflectometry.figures import q_theta_figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wf = EstiaMcStasWorkflow()\n",
+    "wf[Filename[SampleRun]] = estia_mcstas_example('Ni/Ti-multilayer')[3]\n",
+    "wf[Filename[ReferenceRun]] = estia_mcstas_example('reference')\n",
+    "\n",
+    "wf[YIndexLimits] = sc.scalar(35), sc.scalar(64)\n",
+    "wf[ZIndexLimits] = sc.scalar(0), sc.scalar(48 * 32)\n",
+    "wf[BeamDivergenceLimits] = sc.scalar(-0.75, unit='deg'), sc.scalar(0.75, unit='deg')\n",
+    "\n",
+    "wf[WavelengthBins] = sc.geomspace('wavelength', 3.5, 12, 2001, unit='angstrom')\n",
+    "wf[QBins] = 1000\n",
+    "\n",
+    "# There is no proton current data in the McStas files, here we just add some fake proton current\n",
+    "# data to make the workflow run.\n",
+    "wf[ProtonCurrent[SampleRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})\n",
+    "wf[ProtonCurrent[ReferenceRun]] = sc.DataArray(\n",
+    "    sc.array(dims=('time',), values=[]),\n",
+    "    coords={'time': sc.array(dims=('time',), values=[], unit='s')})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Basic McStas workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivity = wf.compute(ReflectivityOverQ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def basic_estia_plot(style: str):\n",
+    "    with plt.style.context(style):\n",
+    "        fig, ax = plt.subplots(layout='constrained', figsize=(3, 2.5))\n",
+    "        _ = reflectivity.hist(Q=150).plot(ax=ax, norm='log')\n",
+    "        ax.set_xlim((0.13, 0.53))\n",
+    "        ax.set_xlabel(r'$Q$ [1/Å]')\n",
+    "        ax.set_ylabel(r'$R(Q)$')\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = basic_estia_plot('default')\n",
+    "fig.savefig(\n",
+    "    \"../../docs/_static/thumbnails/estia_mcstas_reduction_light.svg\",\n",
+    "    transparent=True,\n",
+    ")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = basic_estia_plot('dark_background')\n",
+    "fig.savefig(\n",
+    "    \"../../docs/_static/thumbnails/estia_mcstas_reduction_dark.svg\",\n",
+    "    transparent=True,\n",
+    ")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Advanced McStas workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MaskedReflectivityOverQ = NewType('MaskedReflectivityOverQ', sc.DataArray)\n",
+    "\n",
+    "def mask_noisy_reference(\n",
+    "    reflectivity: ReflectivityOverQ,\n",
+    "    reference: Reference,\n",
+    ") -> MaskedReflectivityOverQ:\n",
+    "    ref = reference.hist(Q=reflectivity.coords['Q'])\n",
+    "    return reflectivity.assign_masks(\n",
+    "        noisy_reference= sc.stddevs(ref).data > 0.3 * ref.data\n",
+    "    )\n",
+    "\n",
+    "wf.insert(mask_noisy_reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param_table = pd.DataFrame({\n",
+    "    Filename[SampleRun]: estia_mcstas_example('Ni/Ti-multilayer')\n",
+    "}).rename_axis(index='run')\n",
+    "\n",
+    "# Make a copy to preserve the original `wf`.\n",
+    "multi_file_workflow = wf.copy()\n",
+    "mapped = multi_file_workflow[MaskedReflectivityOverQ].map(param_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def combine_measurements(*measurements: sc.DataArray) -> sc.DataGroup[sc.DataArray]:\n",
+    "    return sc.DataGroup({\n",
+    "        f\"{da.coords['sample_rotation']:c}\": da for da in measurements\n",
+    "    })\n",
+    "\n",
+    "multi_file_workflow[MaskedReflectivityOverQ] = mapped.reduce(\n",
+    "    func=combine_measurements\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_file_workflow.visualize(\n",
+    "    MaskedReflectivityOverQ,\n",
+    "    graph_attr={\"rankdir\": \"LR\"},\n",
+    "    compact=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples = list(sciline.compute_mapped(multi_file_workflow, Sample))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def advanced_estia_plot(style: str):\n",
+    "    with plt.style.context(style):\n",
+    "        fig, ax = plt.subplots(layout='constrained', figsize=(3, 2.5))\n",
+    "        _ = q_theta_figure(samples, q_bins=100, theta_bins=100, ax=ax)\n",
+    "        ax.set_xlim((0.0, 0.53))\n",
+    "        ax.set_ylim((0.0, 0.15))\n",
+    "        ax.set_xlabel(r'$Q$ [1/Å]')\n",
+    "        ax.set_ylabel(r'$\\theta$ [rad]')\n",
+    "        fig.axes[-1].set_ylabel(None)\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = advanced_estia_plot('default')\n",
+    "fig.savefig(\n",
+    "    \"../../docs/_static/thumbnails/estia_advanced_mcstas_reduction_light.svg\",\n",
+    "    transparent=True,\n",
+    ")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = advanced_estia_plot('dark_background')\n",
+    "fig.savefig(\n",
+    "    \"../../docs/_static/thumbnails/estia_advanced_mcstas_reduction_dark.svg\",\n",
+    "    transparent=True,\n",
+    ")\n",
+    "fig"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/docs/estia-thumbnails.ipynb
+++ b/tools/docs/estia-thumbnails.ipynb
@@ -161,7 +161,7 @@
    "source": [
     "param_table = pd.DataFrame({\n",
     "    Filename[SampleRun]: estia_mcstas_example('Ni/Ti-multilayer')\n",
-    "}).rename_axis(index='run')\n",
+    "}).rename_axis(index='sample_rotation')\n",
     "\n",
     "# Make a copy to preserve the original `wf`.\n",
     "multi_file_workflow = wf.copy()\n",


### PR DESCRIPTION
This is basically the same as what I did with the DREAM user guide. I split the ESTIA guide into a basic notebook that only shows how to reduce some data and an advanced guide that expands on the basic one.

I only did this with the ESTIA docs as the others aren't the main focus of this package.

I removed the sections dealing with different samples because they were identical to the Ni/Ti sample except for different input files. This didn't teach the reader anything new.