### PR TITLE
fix: remove progress when reduction is finished

### DIFF
--- a/src/ess/reflectometry/gui.py
+++ b/src/ess/reflectometry/gui.py
@@ -481,6 +481,7 @@ class ReflectometryBatchReductionGUI:
     def _init_reduction_table_component(self):
         reduce_button = widgets.Button(description="Reduce")
         plot_button = widgets.Button(description="Plot")
+        self.progress_log = widgets.VBox([])
 
         def reduce_data(_):
             self.log("reduce data")
@@ -535,7 +536,7 @@ class ReflectometryBatchReductionGUI:
 
         add_row_button.on_click(add_row)
         delete_row_button.on_click(delete_row)
-        data_buttons = widgets.HBox([reduce_button, plot_button])
+        data_buttons = widgets.HBox([reduce_button, plot_button, self.progress_log])
 
         self.reduction_table_component = widgets.VBox(
             [
@@ -563,19 +564,10 @@ class ReflectometryBatchReductionGUI:
         )
 
     def _init_display_component(self):
-        self.progress_log = widgets.VBox([])
         self.plot_log = widgets.VBox([])
         self.display_component = widgets.VBox(
-            [
-                widgets.VBox(
-                    [widgets.Label("Progress"), self.progress_log],
-                    layout={'width': '100%', 'margin': '10px 0'},
-                ),
-                widgets.VBox(
-                    [widgets.Label("Plots"), self.plot_log],
-                    layout={'width': '100%', 'margin': '10px 0'},
-                ),
-            ]
+            [widgets.Label("Plots"), self.plot_log],
+            layout={'width': '100%', 'margin': '10px 0'},
         )
 
     def _init_settings_component(self):


### PR DESCRIPTION
Previously the progress bar stayed until a new run was issued.
This was confusing because even if the bar is full it looks a bit like the reduction is not finished.
It is extra confusing in cases when one or more of the reductions failed, because then the progress bar does not fill up completely.

This PR makes the progress bar go away when the reduction is finished, clearly demonstrating that the work is done.