### PR TITLE
feat: add Qx

### DIFF
--- a/src/ess/estia/conversions.py
+++ b/src/ess/estia/conversions.py
@@ -27,11 +27,10 @@ def reflectometry_q_x(
     .. math::
         Q_x = \\frac{2 \\pi}{\\lambda} (cos(\\theta_o) - cos(\\theta_i))
 
-    Where :math:`\\theta_o` is the reflection angle (:func:`theta`) and :math:`\\theta_i`
-    is the incident angle on the sample surface.
+    Where :math:`\\theta_o` is the reflection angle (:func:`theta`)
+    and :math:`\\theta_i` is the incident angle on the sample surface.
 
-    Assuming the sample is aligned with the beam the incident angle is what
-    we call the sample rotation.
+    Note that here we assume the incident angle is equal to ``sample_rotation``.
 
     Source:
     `Frédéric Ott, "Off-specular data representations in neutron reflectivity" <https://doi.org/10.1107/S0021889811002858>`_


### PR DESCRIPTION
See second entry in https://confluence.ess.eu/spaces/LSS/pages/788709987/Estia+Reduction+Use+Cases.

Instrument scientist has reviewed the implementation.
Best would be to test this by using it to reduce some offspecular dataset that was measured using a collimated beam in the ESTIA McStas instrument.
But currently we don't have that.