### PR TITLE
fix: rename detector

### DIFF
--- a/src/ess/estia/workflow.py
+++ b/src/ess/estia/workflow.py
@@ -83,7 +83,7 @@ def default_parameters() -> dict:
         CorrectionsToApply: corrections.default_corrections,
         DetectorSpatialResolution: 0.0025 * sc.units.m,
         LookupTableRelativeErrorThreshold: {
-            "detector": float('inf'),
+            "multiblade_detector": float('inf'),
         },
     }
 


### PR DESCRIPTION
Old name seems to have been copied from McStas workflow, but the Nexus name is `multiblade_detector`.