### PR TITLE
Use github releases for nightly reduced data files

### DIFF
--- a/.github/workflows/nightly_at_main.yml
+++ b/.github/workflows/nightly_at_main.yml
@@ -33,3 +33,30 @@ jobs:
       tox-env: ${{ matrix.python.tox-env }}
       test-artifacts-name: 'essreflectometry-test-artifacts-latest'
     secrets: inherit
+
+
+  publish:
+    name: Publish nightly reduced data
+    needs: tests
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download test artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: essreflectometry-test-artifacts-latest
+          path: ./artifacts
+
+      - name: Publish to nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+          gh release create nightly \
+            --target ${{ github.sha }} \
+            --title "Nightly reduced data files" \
+            --notes "Automated nightly build from $(date -u +%Y-%m-%dT%H:%MZ) (commit ${GITHUB_SHA::7})" \
+            --prerelease \
+            ./artifacts/*


### PR DESCRIPTION
Using this repo to test out if this is better way of generating stable URLs so downstream users can consume the nightly reduced data files.